### PR TITLE
Build hermes using a single script.

### DIFF
--- a/utils/build/buildWindows.ps1
+++ b/utils/build/buildWindows.ps1
@@ -1,0 +1,10 @@
+param(
+    [switch]$Release = $false
+)
+
+function Get-ScriptDirectory { Split-Path $MyInvocation.ScriptName }
+$scriptPath = Join-Path (Get-ScriptDirectory) 'configure.py'
+$vsprojPath = Join-Path (Get-ScriptDirectory) '../../build/ALL_BUILD.vcxproj'
+python $scriptPath --build-system='Visual Studio 16 2019' --cmake-flags='-A x64'
+$confiugration = If ($Release -eq $true) {"/p:Configuration=Release"} Else {"/p:Configuration=Debug"}
+MSBuild.exe $vsprojPath $confiugration

--- a/utils/build/configure.py
+++ b/utils/build/configure.py
@@ -33,7 +33,6 @@ def parse_args():
         "--warnings-as-errors", dest="warnings_as_errors", action="store_true"
     )
     parser.add_argument("--static-link", dest="static_link", action="store_true")
-    parser.add_argument("--release", dest="release", action="store_true")
     args = parser.parse_args()
     args.hermes_build_dir = os.path.realpath(args.hermes_build_dir)
     if args.icu_root:
@@ -122,14 +121,6 @@ def main():
         env=os.environ,
         cwd=args.hermes_build_dir,
     )
-
-    msbuild = which("MSBuild.exe")
-    run_command(
-        [msbuild, "ALL_BUILD.vcxproj", "/p:Configuration=Release" if args.release else "/p:Configuration=Debug"],
-        env=os.environ,
-        cwd=args.hermes_build_dir
-    )
-
 
 
 if __name__ == "__main__":

--- a/utils/build/configure.py
+++ b/utils/build/configure.py
@@ -33,6 +33,7 @@ def parse_args():
         "--warnings-as-errors", dest="warnings_as_errors", action="store_true"
     )
     parser.add_argument("--static-link", dest="static_link", action="store_true")
+    parser.add_argument("--release", dest="release", action="store_true")
     args = parser.parse_args()
     args.hermes_build_dir = os.path.realpath(args.hermes_build_dir)
     if args.icu_root:
@@ -121,6 +122,14 @@ def main():
         env=os.environ,
         cwd=args.hermes_build_dir,
     )
+
+    msbuild = which("MSBuild.exe")
+    run_command(
+        [msbuild, "ALL_BUILD.vcxproj", "/p:Configuration=Release" if args.release else "/p:Configuration=Debug"],
+        env=os.environ,
+        cwd=args.hermes_build_dir
+    )
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Tried to addresses https://github.com/microsoft/react-native-windows/projects/25#card-36054669.
Allows user to build hermes using a single call to `utils/build/configure.py`, like so:
```
$ utils/build/configure.py --build-system='Visual Studio 16 2019' --cmake-flags='-A x64'
```
Added `--release` flag which when omitted builds hermes in debug.
This builds all .exes, which I am not sure are different from a UWP binary.
Let me know if you had something different in mind! 