### PR TITLE
Export debugger APIs from the DLL

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -109,6 +109,9 @@ set_target_properties(libhermes PROPERTIES
   OUTPUT_NAME hermes
 )
 
+set_property(TARGET libhermes APPEND_STRING PROPERTY
+  COMPILE_DEFINITIONS "CREATE_SHARED_LIBRARY")
+
 if(APPLE AND HERMES_BUILD_APPLE_FRAMEWORK)
   set_target_properties(libhermes PROPERTIES
     FRAMEWORK TRUE

--- a/API/hermes/hermes.h
+++ b/API/hermes/hermes.h
@@ -208,7 +208,7 @@ class HERMES_EXPORT HermesRuntime : public jsi::Runtime {
   // class in the .cpp file.
 };
 
-__declspec(dllexport) HERMES_EXPORT std::unique_ptr<HermesRuntime> makeHermesRuntime(
+HERMES_EXPORT std::unique_ptr<HermesRuntime> makeHermesRuntime(
     const ::hermes::vm::RuntimeConfig &runtimeConfig =
         ::hermes::vm::RuntimeConfig());
 HERMES_EXPORT std::unique_ptr<jsi::ThreadSafeRuntime>

--- a/ReactNative.Hermes.Windows.targets
+++ b/ReactNative.Hermes.Windows.targets
@@ -1,30 +1,30 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <!-- Set HERMES_ARCH to "win32" for desktop builds -->
-    <HERMES_ARCH Condition="'$(HERMES_ARCH)' == ''">uwp</HERMES_ARCH>
+    <!-- Set HermesAppPlatform to "win32" for desktop builds -->
+    <HermesAppPlatform Condition="'$(HermesAppPlatform)' == ''">uwp</HermesAppPlatform>
 
-    <HERMES_PLATFORM Condition="'$(HERMES_PLATFORM)' == ''">$(Platform)</HERMES_PLATFORM>
+    <HermesPlatform Condition="'$(HermesPlatform)' == ''">$(Platform)</HermesPlatform>
     <!-- Fix platform name (win32 should be x86) -->
-    <HERMES_PLATFORM Condition="'$(HERMES_PLATFORM)' == 'Win32'">x86</HERMES_PLATFORM>
+    <HermesPlatform Condition="'$(HermesPlatform)' == 'Win32'">x86</HermesPlatform>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>
-      <AdditionalLibraryDirectories Condition="'$(Configuration)' == 'Debug'">$(MSBuildThisFileDirectory)..\..\lib\$(HERMES_ARCH)\debug\$(HERMES_PLATFORM);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalLibraryDirectories Condition="'$(Configuration)' == 'Release'">$(MSBuildThisFileDirectory)..\..\lib\$(HERMES_ARCH)\release\$(HERMES_PLATFORM);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Configuration)' == 'Debug'">$(MSBuildThisFileDirectory)..\..\lib\$(HermesAppPlatform)\debug\$(HermesPlatform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Configuration)' == 'Release'">$(MSBuildThisFileDirectory)..\..\lib\$(HermesAppPlatform)\release\$(HermesPlatform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>hermes.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>hermes.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory)include</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemGroup Condition="'$(Configuration)' == 'Debug' And '$(HERMES_NODLLCOPY)' == ''">
-    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(HERMES_ARCH)\debug\$(HERMES_PLATFORM)\hermes.dll" />
-    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(HERMES_ARCH)\debug\$(HERMES_PLATFORM)\hermes.pdb" />
+  <ItemGroup Condition="'$(Configuration)' == 'Debug' And '$(HermesNoDLLCopy)' == ''">
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(HermesAppPlatform)\debug\$(HermesPlatform)\hermes.dll" />
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(HermesAppPlatform)\debug\$(HermesPlatform)\hermes.pdb" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' == 'Release' And '$(HERMES_NODLLCOPY)' == ''">
-    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(HERMES_ARCH)\release\$(HERMES_PLATFORM)\hermes.dll" />
+  <ItemGroup Condition="'$(Configuration)' == 'Release' And '$(HermesNoDLLCopy)' == ''">
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(HermesAppPlatform)\release\$(HermesPlatform)\hermes.dll" />
     <!--  We don't currently build a PDB for release builds
-    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(HERMES_ARCH)\release\$(HERMES_PLATFORM)\hermes.pdb" / -->
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(HermesAppPlatform)\release\$(HermesPlatform)\hermes.pdb" / -->
   </ItemGroup>
 </Project>

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.1",
+  "version": "0.6.2",
   "scripts": {
     "unpack-builds": "node unpack-builds.js",
     "unpack-builds-dev": "node unpack-builds.js --dev",


### PR DESCRIPTION
Export Debugger APIs alongside with makeHermesRuntime (for use in RNW).
Change MSBuild variable names to follow standard casing.
Clean up the build script a little bit.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/hermes-windows/pull/14)