### PR TITLE
Bug fixes

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -91,10 +91,12 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
   set(compile_flags "")
   set(link_flags "/O2 ${OPTIONAL_GC_SECTIONS} ${OPTIONAL_JNI_ONLOAD}")
 
-  # Generate a PDB for debug builds
+  # Generate PDBs
+  set(compile_flags "${compile_flags} /Zi")
   if("{CMAKE_BUILD_TYPE}" MATCHES "Debug")
-    set(compile_flags "${compile_flags} /Zi")
     set(link_flags "${link_flags} /DEBUG")
+  else()
+    set(link_flags "${link_flags} /DEBUG /OPT:REF /OPT:ICF")
   endif()
 
 endif()

--- a/API/hermes/hermes.h
+++ b/API/hermes/hermes.h
@@ -208,7 +208,7 @@ class HERMES_EXPORT HermesRuntime : public jsi::Runtime {
   // class in the .cpp file.
 };
 
-HERMES_EXPORT std::unique_ptr<HermesRuntime> makeHermesRuntime(
+HERMES_EXPORT std::unique_ptr<HermesRuntime> __cdecl makeHermesRuntime(
     const ::hermes::vm::RuntimeConfig &runtimeConfig =
         ::hermes::vm::RuntimeConfig());
 HERMES_EXPORT std::unique_ptr<jsi::ThreadSafeRuntime>

--- a/ReactNative.Hermes.Windows.nuspec
+++ b/ReactNative.Hermes.Windows.nuspec
@@ -13,5 +13,6 @@
     <file src="$nugetroot$\lib\**\*.*" target="lib" exclude="**\*.manifest;**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
     <file src="$nugetroot$\build\**\*.*" target="build"/>
     <file src="$nugetroot$\license\*.*" target="license"/>
+    <file src="$nugetroot$\tools\*.*" target="tools"/>
   </files>
 </package>

--- a/ReactNative.Hermes.Windows.targets
+++ b/ReactNative.Hermes.Windows.targets
@@ -9,10 +9,11 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>
-      <AdditionalLibraryDirectories Condition="'$(Configuration)' == 'Debug'">$(MSBuildThisFileDirectory)..\..\lib\$(HermesAppPlatform)\debug\$(HermesPlatform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalLibraryDirectories Condition="'$(Configuration)' == 'Release'">$(MSBuildThisFileDirectory)..\..\lib\$(HermesAppPlatform)\release\$(HermesPlatform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>hermes.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <DelayLoadDLLs>hermes.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <AdditionalLibraryDirectories Condition="'$(Configuration)' == 'Debug'">%(AdditionalLibraryDirectories);$(MSBuildThisFileDirectory)..\..\lib\$(HermesAppPlatform)\debug\$(HermesPlatform)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Configuration)' == 'Release'">%(AdditionalLibraryDirectories);$(MSBuildThisFileDirectory)..\..\lib\$(HermesAppPlatform)\release\$(HermesPlatform)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies);hermes.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(HermesAppPlatform)' == 'uwp'">%(AdditionalDependencies);dloadhelper.lib</AdditionalDependencies>
+      <DelayLoadDLLs>%(DelayLoadDLLs);hermes.dll</DelayLoadDLLs>
     </Link>
     <ClCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory)include</AdditionalIncludeDirectories>
@@ -24,7 +25,6 @@
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Release' And '$(HermesNoDLLCopy)' == ''">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(HermesAppPlatform)\release\$(HermesPlatform)\hermes.dll" />
-    <!--  We don't currently build a PDB for release builds
-    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(HermesAppPlatform)\release\$(HermesPlatform)\hermes.pdb" / -->
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(HermesAppPlatform)\release\$(HermesPlatform)\hermes.pdb" />
   </ItemGroup>
 </Project>

--- a/cibuild.ps1
+++ b/cibuild.ps1
@@ -137,8 +137,16 @@ function Run-Build($SourcesPath, $OutputPath, $Platform, $Configuration, $AppPla
         New-Item -ItemType "directory" -Path "$OutputPath\lib\$AppPlatform\$Configuration\$Platform" | Out-Null
     }
 
+    if (!(Test-Path -Path "$OutputPath\tools")) {
+        New-Item -ItemType "directory" -Path "$OutputPath\tools" | Out-Null
+    }
+
     Copy-Item "$buildPath\API\hermes\hermes.*" -Destination "$OutputPath\lib\$AppPlatform\$Configuration\$Platform"
-    Copy-Item "$buildPath\bin\hermes.*" -Destination "$OutputPath\lib\$AppPlatform\$Configuration\$Platform"
+
+    # The Hermes bytecode is platform-independent, so only copy the compiler once
+    if ($AppPlatform -eq "win32" -And $Platform -eq "x86" -And $Configuration -eq "release") {
+        Copy-Item "$buildPath\bin\hermes.*" -Destination "$OutputPath\tools"
+    }
 
     Pop-Location
 }

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.3",
+  "version": "0.6.4",
   "scripts": {
     "unpack-builds": "node unpack-builds.js",
     "unpack-builds-dev": "node unpack-builds.js --dev",


### PR DESCRIPTION
Build and include PDBs for the release flavor;
Only include one compiler binary (since the bytecode is platform-independent we don't need architecture-specific compiler builds);
Fix the include directory order (to avoid issues with multiple JSI headers in RNW);

Fixes #18, #23 and #24.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/hermes-windows/pull/26)