### PR TITLE
Fix for tools binaries not included in nuget

### DIFF
--- a/ReactNative.Hermes.Windows.nuspec
+++ b/ReactNative.Hermes.Windows.nuspec
@@ -13,6 +13,6 @@
     <file src="$nugetroot$\lib\**\*.*" target="lib" exclude="**\*.manifest;**\*.iobj;**\*.ipdb;**\*.pdb;**\*.exp;**\*.ilk" />
     <file src="$nugetroot$\build\**\*.*" target="build"/>
     <file src="$nugetroot$\license\*.*" target="license"/>
-    <file src="$nugetroot$\tools\*.*" target="tools"/>
+    <file src="$nugetroot$\tools\**\*.*" target="tools"/>
   </files>
 </package>

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.2-microsoft.3",
+  "version": "0.7.2-microsoft.5",
   "scripts": {
     "unpack-builds": "node unpack-builds.js",
     "unpack-builds-dev": "node unpack-builds.js --dev",


### PR DESCRIPTION
Tools artefacts were not getting published because of a bug in the NuSpec.

## Summary

Tools artefacts were not getting published because of a bug in the NuSpec.

## Test Plan
Verified creating NuGet package.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/31)