### PR TITLE
Fixing x86 calling convention and avoiding delayloading hermesinspector when not needed

### DIFF
--- a/.ado/ReactNative.Hermes.Windows.targets
+++ b/.ado/ReactNative.Hermes.Windows.targets
@@ -17,7 +17,8 @@
       <AdditionalDependencies>%(AdditionalDependencies);hermes.lib;</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' Or '$(EnableHermesInspectorInReleaseFlavor)' == 'true'">%(AdditionalDependencies);hermesinspector.lib;</AdditionalDependencies>
       <AdditionalDependencies>%(AdditionalDependencies);dloadhelper.lib</AdditionalDependencies>
-      <DelayLoadDLLs>%(DelayLoadDLLs);hermes.dll;hermesinspector.dll</DelayLoadDLLs>
+      <DelayLoadDLLs>%(DelayLoadDLLs);hermes.dll;</DelayLoadDLLs>
+      <DelayLoadDLLs Condition="'$(Configuration)' == 'Debug' Or '$(EnableHermesInspectorInReleaseFlavor)' == 'true'">%(DelayLoadDLLs);hermesinspector.dll</DelayLoadDLLs>
     </Link>
     <ClCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(PackageRoot)\build\native\include</AdditionalIncludeDirectories>

--- a/API/hermes/hermes.h
+++ b/API/hermes/hermes.h
@@ -97,13 +97,13 @@ class HERMES_EXPORT HermesRuntime : public jsi::Runtime {
       size_t len);
 
   /// Enable sampling profiler.
-  static void enableSamplingProfiler();
+  static void __cdecl enableSamplingProfiler();
 
   /// Disable the sampling profiler
-  static void disableSamplingProfiler();
+  static void __cdecl disableSamplingProfiler();
 
   /// Dump sampled stack trace to the given file name.
-  static void dumpSampledTraceToFile(const std::string &fileName);
+  static void __cdecl dumpSampledTraceToFile(const std::string &fileName);
 
   /// Dump sampled stack trace to the given stream.
   static void dumpSampledTraceToStream(llvh::raw_ostream &stream);

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.1-ms.4",
+  "version": "0.8.1-ms.5",
   "scripts": {
     "unpack-builds": "node unpack-builds.js",
     "unpack-builds-dev": "node unpack-builds.js --dev",


### PR DESCRIPTION
Fixing x86 calling convention and avoiding delayloading hermesinspector when not needed


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/41)