### PR TITLE
Adding CODEOWNER for hermes-windows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @microsoft/react-native-windows-write

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @microsoft/react-native-windows-write
+* @microsoft/jshost


### PR DESCRIPTION
Making react-native-windows-write and jshost as owners of the hermes-windows repo ..

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/46)