### PR TITLE
FastDebug build flavor and HermesNoLink msbuild flag

### DIFF
--- a/.ado/ReactNative.Hermes.Windows.targets
+++ b/.ado/ReactNative.Hermes.Windows.targets
@@ -10,15 +10,15 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>
-      <AdditionalLibraryDirectories Condition="'$(Configuration)' == 'Debug'">%(AdditionalLibraryDirectories);$(PackageRoot)lib\native\release\$(HermesPlatform)\checkediterdebugger</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Configuration)' == 'Debug'">%(AdditionalLibraryDirectories);$(PackageRoot)lib\native\debug\$(HermesPlatform)</AdditionalLibraryDirectories>
       <AdditionalLibraryDirectories Condition="'$(Configuration)' == 'Release' And '$(EnableHermesInspectorInReleaseFlavor)' != 'true' ">%(AdditionalLibraryDirectories);$(PackageRoot)lib\native\release\$(HermesPlatform)</AdditionalLibraryDirectories>
       <AdditionalLibraryDirectories Condition="'$(Configuration)' == 'Release' And '$(EnableHermesInspectorInReleaseFlavor)' == 'true'">%(AdditionalLibraryDirectories);$(PackageRoot)lib\native\release\$(HermesPlatform)\debugger</AdditionalLibraryDirectories>
       
-      <AdditionalDependencies>%(AdditionalDependencies);hermes.lib;</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' Or '$(EnableHermesInspectorInReleaseFlavor)' == 'true'">%(AdditionalDependencies);hermesinspector.lib;</AdditionalDependencies>
-      <AdditionalDependencies>%(AdditionalDependencies);dloadhelper.lib</AdditionalDependencies>
-      <DelayLoadDLLs>%(DelayLoadDLLs);hermes.dll;</DelayLoadDLLs>
-      <DelayLoadDLLs Condition="'$(Configuration)' == 'Debug' Or '$(EnableHermesInspectorInReleaseFlavor)' == 'true'">%(DelayLoadDLLs);hermesinspector.dll</DelayLoadDLLs>
+      <AdditionalDependencies Condition="'$(HermesNoLink)' == ''">%(AdditionalDependencies);hermes.lib;</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(HermesNoLink)' == '' And ('$(Configuration)' == 'Debug' Or '$(EnableHermesInspectorInReleaseFlavor)' == 'true')">%(AdditionalDependencies);hermesinspector.lib;</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(HermesNoLink)' == ''">%(AdditionalDependencies);dloadhelper.lib</AdditionalDependencies>
+      <DelayLoadDLLs Condition="'$(HermesNoLink)' == ''">%(DelayLoadDLLs);hermes.dll;</DelayLoadDLLs>
+      <DelayLoadDLLs Condition="'$(HermesNoLink)' == '' And ('$(Configuration)' == 'Debug' Or '$(EnableHermesInspectorInReleaseFlavor)' == 'true')">%(DelayLoadDLLs);hermesinspector.dll</DelayLoadDLLs>
     </Link>
     <ClCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(PackageRoot)\build\native\include</AdditionalIncludeDirectories>
@@ -27,8 +27,8 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Debug' And '$(HermesNoDLLCopy)' == ''">
-    <ReferenceCopyLocalPaths Include="$(PackageRoot)lib\native\release\$(HermesPlatform)\checkediterdebugger\hermes.dll" />
-    <ReferenceCopyLocalPaths Include="$(PackageRoot)lib\native\release\$(HermesPlatform)\checkediterdebugger\hermesinspector.dll" />
+    <ReferenceCopyLocalPaths Include="$(PackageRoot)lib\native\debug\$(HermesPlatform)\hermes.dll" />
+    <ReferenceCopyLocalPaths Include="$(PackageRoot)lib\native\debug\$(HermesPlatform)\hermesinspector.dll" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Release' And '$(EnableHermesInspectorInReleaseFlavor)' != 'true' And '$(HermesNoDLLCopy)' == ''">
     <ReferenceCopyLocalPaths Include="$(PackageRoot)lib\native\release\$(HermesPlatform)\hermes.dll" />

--- a/cmake/modules/Hermes.cmake
+++ b/cmake/modules/Hermes.cmake
@@ -46,6 +46,17 @@ elseif (MINGW) # FIXME: Also cygwin?
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--stack,16777216")
 endif ()
 
+if(MSVC)
+  # FastDebug Flavor
+  # 1. Optmize for speed.
+  # 2. Enable full Inlining
+  # 3. Link against debug flavored VCRT
+  # Note: /O2 and RTC1 are incompatible
+  # TODO: /Ox is more debug friendly ?
+  string(APPEND CMAKE_CXX_FLAGS_FASTDEBUG "/MDd /O2 /Ob2")
+  string(APPEND CMAKE_C_FLAGS_FASTDEBUG "/MDd /O2 /Ob2")
+endif()
+
 if (WIN32)
   set(LLVM_HAVE_LINK_VERSION_SCRIPT 0)
   if (CYGWIN)


### PR DESCRIPTION
## Summary

1. Improve the speed/stability of Windows debug builds.
2. Add an MSBuild flag to avoid linking against Hermes library (Need to be revised/thought further)

These are the script evaluation duration on each flavors,

Debug
4890.5564999580383
5232.4257000088692

Fast Debug
1169.1592999696732
1067.1070999503136

Release with checked iterator
497.69550001621246
487.46139997243881



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/47)