### PR TITLE
Add WER CrashManager and a crashHandler for win32

### DIFF
--- a/.ado/scripts/cibuild.ps1
+++ b/.ado/scripts/cibuild.ps1
@@ -143,7 +143,7 @@ function Invoke-BuildImpl($SourcesPath, $buildPath, $genArgs, $targets, $increme
     Push-Location $buildPath
 
     $genCall = ('cmake {0}' -f ($genArgs -Join ' ')) + " $SourcesPath";
-    Write-Host $genCall | Out-Null
+    Write-Host $genCall
     $ninjaCmd = "ninja"
 
     foreach ( $target in $targets )
@@ -151,7 +151,7 @@ function Invoke-BuildImpl($SourcesPath, $buildPath, $genArgs, $targets, $increme
         $ninjaCmd = $ninjaCmd + " " + $target
     }
 
-    Write-Output $ninjaCmd | Out-Null
+    Write-Host $ninjaCmd
 
     # See https://developercommunity.visualstudio.com/content/problem/257260/vcvarsallbat-reports-the-input-line-is-too-long-if.html
     $Bug257260 = $false
@@ -172,7 +172,7 @@ function Invoke-BuildImpl($SourcesPath, $buildPath, $genArgs, $targets, $increme
 
     } else {
         $GenCmd = "`"$VCVARS_PATH`" $(Get-VCVarsParam $Platform $AppPlatform) && $genCall 2>&1"
-        Write-Output "Command: $GenCmd" | Out-Null
+        Write-Host "Command: $GenCmd"
         cmd /c $GenCmd
 
         if($ConfigureOnly.IsPresent){
@@ -180,7 +180,7 @@ function Invoke-BuildImpl($SourcesPath, $buildPath, $genArgs, $targets, $increme
         }
 
         $NinjaCmd = "`"$VCVARS_PATH`" $(Get-VCVarsParam $Platform $AppPlatform) && ${ninjaCmd} 2>&1"
-        Write-Output "Command: $NinjaCmd" | Out-Null
+        Write-Host "Command: $NinjaCmd"
         cmd /c $NinjaCmd
     }
 

--- a/API/hermes/hermes.h
+++ b/API/hermes/hermes.h
@@ -256,6 +256,12 @@ HERMES_EXPORT std::unique_ptr<jsi::ThreadSafeRuntime>
 makeThreadSafeHermesRuntime(
     const ::hermes::vm::RuntimeConfig &runtimeConfig =
         ::hermes::vm::RuntimeConfig());
+
+#if defined(_WIN32)
+HERMES_EXPORT std::unique_ptr<HermesRuntime> __cdecl makeHermesRuntimeWithWER();
+HERMES_EXPORT void __cdecl hermesCrashHandler(HermesRuntime &runtime, int fd);
+#endif
+
 } // namespace hermes
 } // namespace facebook
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.9.0-ms.7",
+  "version": "0.9.0-ms.8",
   "scripts": {
     "unpack-builds": "node unpack-builds.js",
     "unpack-builds-dev": "node unpack-builds.js --dev",


### PR DESCRIPTION
Add win32 exports for creating a runtime with a default CrashManager implementation that forwards calls into Windows Error Reporting (Watson) and a crashHandler that can output details (such as callstack) to a file handle.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/55)