### PR TITLE
Split PR and CI in two yamls so we can run publish on internal ADO instance

### DIFF
--- a/.ado/jobs.yml
+++ b/.ado/jobs.yml
@@ -1,0 +1,172 @@
+jobs:
+  - job: HermesBuildAll
+    timeoutInMinutes: 120
+    displayName: (PR) Build the Hermes binary for supported architectures and flavors
+    strategy:
+      matrix:
+        DebugX64:
+          BuildConfiguration: debug
+          BuildPlatform: x64
+        DebugX86:
+          BuildConfiguration: debug
+          BuildPlatform: x86
+        DebugARM:
+          BuildConfiguration: debug
+          BuildPlatform: arm
+        DebugARM64:
+          BuildConfiguration: debug
+          BuildPlatform: arm64
+        ReleaseX64:
+          BuildConfiguration: release
+          BuildPlatform: x64
+        ReleaseX86:
+          BuildConfiguration: release
+          BuildPlatform: x86
+        ReleaseARM:
+          BuildConfiguration: release
+          BuildPlatform: arm
+        ReleaseARM64:
+          BuildConfiguration: release
+          BuildPlatform: arm64
+
+    steps:
+      - task: PowerShell@2
+        displayName: Run the build script
+        enabled: false
+        inputs:
+          targetType: filePath
+          filePath: $(Build.SourcesDirectory)\.ado\scripts\cibuild.ps1
+          arguments:
+            -SourcesPath:$(Build.SourcesDirectory)
+            -OutputPath:$(Build.ArtifactStagingDirectory)
+            -Platform:$(BuildPlatform)
+            -Configuration:$(BuildConfiguration)
+            -AppPlatform:uwp
+
+      - task: PublishBuildArtifacts@1
+        displayName: "Publish artifacts"
+        inputs:
+          artifactName: HermesArtifacts
+          pathtoPublish: $(Build.ArtifactStagingDirectory)
+
+  - job: HermesBuildForPublish
+    timeoutInMinutes: 120
+    displayName: (Publish) Build the Hermes binary for supported architectures and flavors
+    strategy:
+      matrix:
+        DebugX64:
+          BuildConfiguration: debug
+          BuildPlatform: x64
+        DebugX86:
+          BuildConfiguration: debug
+          BuildPlatform: x86
+        DebugARM64:
+          BuildConfiguration: debug
+          BuildPlatform: arm64
+        DebugARM:
+          BuildConfiguration: debug
+          BuildPlatform: arm
+        ReleaseX64:
+          BuildConfiguration: release
+          BuildPlatform: x64
+        ReleaseX86:
+          BuildConfiguration: release
+          BuildPlatform: x86
+        ReleaseARM64:
+          BuildConfiguration: release
+          BuildPlatform: arm64
+        ReleaseARM:
+          BuildConfiguration: release
+          BuildPlatform: arm
+
+    steps:
+      - task: PowerShell@2
+        displayName: Run the build script for publish
+        inputs:
+          targetType: filePath
+          filePath: $(Build.SourcesDirectory)\.ado\scripts\cibuild.ps1
+          arguments:
+            -SourcesPath:$(Build.SourcesDirectory)
+            -OutputPath:$(Build.ArtifactStagingDirectory)
+            -Platform:$(BuildPlatform)
+            -Configuration:$(BuildConfiguration)
+            -AppPlatform:uwp
+
+      - script: mkdir $(Build.ArtifactStagingDirectory)\_manifest\$(BuildPlatform)\$(BuildFlavor)
+
+      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+        displayName: 📒 Generate Manifest
+        inputs:
+          BuildDropPath: $(Build.ArtifactStagingDirectory)
+          ManifestDirPath: $(Build.ArtifactStagingDirectory)/_manifest/$(BuildPlatform)/$(BuildFlavor)
+
+      - task: PublishBuildArtifacts@1
+        displayName: "Publish artifacts"
+        inputs:
+          artifactName: HermesArtifacts
+          pathtoPublish: $(Build.ArtifactStagingDirectory)
+
+      # Make symbols available through http://symweb.
+      - task: PublishSymbols@2
+        displayName: Publish symbols
+        condition: not(eq(variables['Build.Reason'], 'PullRequest'))
+        inputs:
+          SearchPattern: $(Build.ArtifactStagingDirectory)/**/*.pdb
+          SymbolServerType: TeamServices
+
+  - job: HermesPublishNuget
+    dependsOn:
+      - HermesBuildForPublish
+    displayName: Publish Nuget
+    steps:
+      - checkout: none
+
+      # The commit tag in the nuspec requires that we use at least nuget 4.6
+      - task: NuGetToolInstaller@0
+        inputs:
+          versionSpec: ">=4.6.0"
+
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Build outputs
+        inputs:
+          artifactName: HermesArtifacts
+          downloadPath: $(System.DefaultWorkingDirectory)
+
+      - task: PowerShell@2
+        inputs:
+          targetType: 'inline'
+          script: |
+            $Version = (Get-Content (Join-Path $(System.DefaultWorkingDirectory) "HermesArtifacts\version") | Out-String).Trim()
+            Write-Host "##vso[task.setvariable variable=Version]$Version"
+
+      - task: NuGetCommand@2
+        displayName: 'NuGet Pack'
+        inputs:
+          command: pack
+          packagesToPack: $(System.DefaultWorkingDirectory)\HermesArtifacts\ReactNative.Hermes.Windows.nuspec
+          packDestination: $(System.DefaultWorkingDirectory)\NugetRootFinal
+          buildProperties: CommitId=$(Build.SourceVersion);nugetroot=$(System.DefaultWorkingDirectory)\HermesArtifacts;RepoUri=$(Build.Repository.Uri)
+          versioningScheme: byEnvVar
+          versionEnvVar: Version
+        
+      - task: NuGetCommand@2
+        displayName: 'NuGet Pack'
+        inputs:
+          command: pack
+          packagesToPack: $(System.DefaultWorkingDirectory)\HermesArtifacts\ReactNative.Hermes.Windows.Fat.nuspec
+          packDestination: $(System.DefaultWorkingDirectory)\NugetRootFinal
+          buildProperties: CommitId=$(Build.SourceVersion);nugetroot=$(System.DefaultWorkingDirectory)\HermesArtifacts;RepoUri=$(Build.Repository.Uri)
+          versioningScheme: byEnvVar
+          versionEnvVar: Version
+
+      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+        displayName: 📒 Generate Manifest NuGet
+        inputs:
+          BuildDropPath: $(System.DefaultWorkingDirectory)\NugetRootFinal
+
+      - task: PublishBuildArtifacts@1
+        displayName: "Publish final nuget artifacts"
+        inputs:
+          PathtoPublish: $(System.DefaultWorkingDirectory)\NugetRootFinal
+          ArtifactName: "Hermes-final-nuget"
+

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -1,10 +1,10 @@
 name: 0.0.$(Date:yyMM.d)$(Rev:rrr)
 
-pr:
+trigger:
   - main
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'OE-OfficePublic'
 
 variables:
   - template: variables.yml

--- a/.ado/variables.yml
+++ b/.ado/variables.yml
@@ -1,0 +1,6 @@
+variables:
+  - group: Hermes-Windows Secrets
+  - name: ArtifactServices.Symbol.AccountName
+    value: microsoft
+  - name: ArtifactServices.Symbol.PAT
+    value: $(pat-symbols-publish-microsoft)


### PR DESCRIPTION
## Summary

For compliance reasons we can't run the publish pipeline on the public dev.azure.com/ms/hermes-windows anymore. We have to migrate it to a private instance.
For that we have to split up the yaml in two parts.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/74)