### PR TITLE
Removing unused yarn.lock files from reactnative package

### DIFF
--- a/API/inspector/react-native/CMakeLists.txt
+++ b/API/inspector/react-native/CMakeLists.txt
@@ -36,6 +36,10 @@ if(NOT reactnative_POPULATED)
     "${file_text}"
   )
   file(WRITE ${reactnative_SOURCE_DIR}/ReactCommon/hermes/inspector/chrome/Registration.h "${file_text}")
+
+  file(GLOB_RECURSE YARN_FILES ${reactnative_SOURCE_DIR}/yarn.lock ${reactnative_SOURCE_DIR}/**/yarn.lock)
+  message("Removing unused yarn.lock files: ${YARN_FILES}")
+  file(REMOVE ${YARN_FILES})
 endif()
 
 set(REACT_NATIVE_SOURCE ${reactnative_SOURCE_DIR} PARENT_SCOPE)


### PR DESCRIPTION
The cmake reactnative package is used only for building hermesinspector.dll; this gets rid of the unused yarn.lock files that trip up the complaince tasks.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/83)