### PR TITLE
Simplify builds (remove checkediterdebugger and arm)

### DIFF
--- a/.ado/ReactNative.Hermes.Windows.UAP.targets
+++ b/.ado/ReactNative.Hermes.Windows.UAP.targets
@@ -9,8 +9,8 @@
     <PackageRoot Condition="'$(NugetRootOverride)' != ''">$(NugetRootOverride)</PackageRoot>
   </PropertyGroup>
  <ItemGroup Condition="'$(Configuration)' == 'Debug' And '$(HermesNoDLLCopy)' == ''">
-    <ReferenceCopyLocalPaths Include="$(PackageRoot)lib\native\release\$(HermesPlatform)\checkediterdebugger\hermes.dll" />
-    <ReferenceCopyLocalPaths Include="$(PackageRoot)lib\native\release\$(HermesPlatform)\checkediterdebugger\hermesinspector.dll" />
+    <ReferenceCopyLocalPaths Include="$(PackageRoot)lib\native\debug\$(HermesPlatform)\hermes.dll" />
+    <ReferenceCopyLocalPaths Include="$(PackageRoot)lib\native\debug\$(HermesPlatform)\hermesinspector.dll" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Release' And '$(EnableHermesInspectorInReleaseFlavor)' != 'true' And '$(HermesNoDLLCopy)' == ''">
     <ReferenceCopyLocalPaths Include="$(PackageRoot)lib\native\release\$(HermesPlatform)\hermes.dll" />

--- a/.ado/jobs.yml
+++ b/.ado/jobs.yml
@@ -13,9 +13,6 @@ jobs:
         DebugARM64:
           BuildConfiguration: debug
           BuildPlatform: arm64
-        DebugARM:
-          BuildConfiguration: debug
-          BuildPlatform: arm
         ReleaseX64:
           BuildConfiguration: release
           BuildPlatform: x64
@@ -25,9 +22,6 @@ jobs:
         ReleaseARM64:
           BuildConfiguration: release
           BuildPlatform: arm64
-        ReleaseARM:
-          BuildConfiguration: release
-          BuildPlatform: arm
 
     steps:
       - task: PowerShell@2
@@ -78,6 +72,7 @@ jobs:
             AnalyzeVerbose: true
             toolVersion: 'LatestPreRelease'
         continueOnError: true
+        condition: and(eq(variables.BuildConfiguration, 'Release'), not(eq(variables.BuildPlatform, 'arm64')))
 
       - task: ComponentGovernanceComponentDetection@0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ project(Hermes
         VERSION 0.11.0
         LANGUAGES C CXX)
 # Optional suffix like "rc3"
-set(VERSION_SUFFIX "ms.3")
+set(VERSION_SUFFIX "ms.4")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.11.0-ms.3",
+  "version": "0.11.0-ms.4",
   "scripts": {
     "unpack-builds": "node unpack-builds.js",
     "unpack-builds-dev": "node unpack-builds.js --dev",


### PR DESCRIPTION
Remove the checkediterdebugger variant of the release DLLs, and the legacy arm architecture, which helps speed up the builds.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/86)