### PR TITLE
[Draft - InProgress] Fix ABI break by adding in createPropNameIDFromSymbol

### DIFF
--- a/API/hermes/TracingRuntime.cpp
+++ b/API/hermes/TracingRuntime.cpp
@@ -219,6 +219,16 @@ jsi::PropNameID TracingRuntime::createPropNameIDFromString(
   return res;
 }
 
+jsi::PropNameID TracingRuntime::createPropNameIDFromSymbol(
+    const jsi::Symbol &sym) {
+  jsi::PropNameID res = RD::createPropNameIDFromSymbol(sym);
+  trace_.emplace_back<SynthTrace::CreatePropNameIDRecord>(
+      getTimeSinceStart(),
+      getUniqueID(res),
+      SynthTrace::encodeSymbol(getUniqueID(sym)));
+  return res;
+}
+
 jsi::Value TracingRuntime::getProperty(
     const jsi::Object &obj,
     const jsi::String &name) {

--- a/API/hermes/TracingRuntime.h
+++ b/API/hermes/TracingRuntime.h
@@ -52,6 +52,7 @@ class TracingRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
   jsi::PropNameID createPropNameIDFromUtf8(const uint8_t *utf8, size_t length)
       override;
   jsi::PropNameID createPropNameIDFromString(const jsi::String &str) override;
+  jsi::PropNameID createPropNameIDFromSymbol(const jsi::Symbol &sym) override;
 
   jsi::Value getProperty(const jsi::Object &obj, const jsi::String &name)
       override;

--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -698,6 +698,7 @@ class HermesRuntimeImpl final : public HermesRuntime,
   jsi::PropNameID createPropNameIDFromUtf8(const uint8_t *utf8, size_t length)
       override;
   jsi::PropNameID createPropNameIDFromString(const jsi::String &str) override;
+  jsi::PropNameID createPropNameIDFromSymbol(const jsi::Symbol &sym) override;
   std::string utf8(const jsi::PropNameID &) override;
   bool compare(const jsi::PropNameID &, const jsi::PropNameID &) override;
 
@@ -1530,6 +1531,11 @@ jsi::PropNameID HermesRuntimeImpl::createPropNameIDFromString(
     checkStatus(cr.getStatus());
     return add<jsi::PropNameID>(cr->getHermesValue());
   });
+}
+
+jsi::PropNameID HermesRuntimeImpl::createPropNameIDFromSymbol(
+    const jsi::Symbol &sym) {
+  return add<jsi::PropNameID>(phv(sym));
 }
 
 std::string HermesRuntimeImpl::utf8(const jsi::PropNameID &sym) {

--- a/API/jsi/jsi/decorator.h
+++ b/API/jsi/jsi/decorator.h
@@ -176,6 +176,9 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   PropNameID createPropNameIDFromString(const String& str) override {
     return plain_.createPropNameIDFromString(str);
   };
+  PropNameID createPropNameIDFromSymbol(const Symbol& sym) override {
+    return plain_.createPropNameIDFromSymbol(sym);
+  };
   std::string utf8(const PropNameID& id) override {
     return plain_.utf8(id);
   };
@@ -552,6 +555,10 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
   PropNameID createPropNameIDFromString(const String& str) override {
     Around around{with_};
     return RD::createPropNameIDFromString(str);
+  };
+  PropNameID createPropNameIDFromSymbol(const Symbol& sym) override {
+    Around around{with_};
+    return RD::createPropNameIDFromSymbol(sym);
   };
   std::string utf8(const PropNameID& id) override {
     Around around{with_};

--- a/API/jsi/jsi/jsi.h
+++ b/API/jsi/jsi/jsi.h
@@ -274,6 +274,7 @@ class JSI_EXPORT Runtime {
       const uint8_t* utf8,
       size_t length) = 0;
   virtual PropNameID createPropNameIDFromString(const String& str) = 0;
+  virtual PropNameID createPropNameIDFromSymbol(const Symbol& sym) = 0;
   virtual std::string utf8(const PropNameID&) = 0;
   virtual bool compare(const PropNameID&, const PropNameID&) = 0;
 
@@ -421,6 +422,11 @@ class JSI_EXPORT PropNameID : public Pointer {
   /// Create a PropNameID from a JS string.
   static PropNameID forString(Runtime& runtime, const jsi::String& str) {
     return runtime.createPropNameIDFromString(str);
+  }
+
+  /// Create a PropNameID from a JS symbol.
+  static PropNameID forSymbol(Runtime& runtime, const jsi::Symbol& sym) {
+    return runtime.createPropNameIDFromSymbol(sym);
   }
 
   // Creates a vector of PropNameIDs constructed from given arguments.


### PR DESCRIPTION
## Summary
Latest RNW integrations (https://github.com/microsoft/react-native-windows/pull/9672) caused an ABI break because a new function was added ( see https://github.com/microsoft/react-native-windows/issues/9703 and https://github.com/facebook/react-native/commit/9010bfe457b77862024214ce6210504ff1786ef5). This adds in createPropNameIDFromSymbol which is already added upstream.

## Test Plan



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/93)