### PR TITLE
Fixes for 0.11

### DIFF
--- a/.ado/ReactNative.Hermes.Windows.nuspec
+++ b/.ado/ReactNative.Hermes.Windows.nuspec
@@ -22,7 +22,7 @@
     <file src="$nugetroot$\build\native\ReactNative.Hermes.Windows.targets" target="build/native/ReactNative.Hermes.Windows.targets" />
     <file src="$nugetroot$\build\uap\ReactNative.Hermes.Windows.targets" target="build/uap/ReactNative.Hermes.Windows.targets" />
     
-    <file src="$nugetroot$\license\*.*" target="license"/>
+    <file src="$nugetroot$\license\*" target="license"/>
     <file src="$nugetroot$\tools\**\*.*" target="tools"/>
   </files>
 </package>

--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -3,6 +3,7 @@ name: 0.0.$(Date:yyMM.d)$(Rev:rrr)
 trigger: none
 pr:
   - main
+  - temp/v0.11
 
 pool:
   vmImage: 'windows-latest'

--- a/.ado/scripts/cibuild.ps1
+++ b/.ado/scripts/cibuild.ps1
@@ -129,6 +129,7 @@ function get-CommonArgs($Platform, $Configuration, $AppPlatform, [ref]$genArgs) 
     $genArgs.Value += ('-DCMAKE_BUILD_TYPE={0}' -f (Get-CMakeConfiguration $Configuration))
 
     $genArgs.Value += '-DHERMESVM_PLATFORM_LOGGING=On'
+    $genArgs.Value += '-DHERMESJSI_DISABLE_STATS_TIMER=On'
 }
 
 function Invoke-BuildImpl($SourcesPath, $buildPath, $genArgs, $targets, $incrementalBuild, $Platform, $Configuration, $AppPlatform) {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,22 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
   endif()
 endif()
 
+if ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
+  # Enable source linking
+  # NOTE: Dependencies are not properly setup here.
+  #       Currently, CMake does not know to re-link if SOURCE_LINK_JSON changes
+  #       Currently, CMake does not re-generate SOURCE_LINK_JSON if git's HEAD changes
+  if ("${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER_EQUAL "19.20")
+    include(SourceLink)
+    file(TO_NATIVE_PATH "${PROJECT_BINARY_DIR}/source_link.json" SOURCE_LINK_JSON)
+    source_link(${PROJECT_SOURCE_DIR} ${SOURCE_LINK_JSON})
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SOURCELINK:${SOURCE_LINK_JSON}")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /SOURCELINK:${SOURCE_LINK_JSON}")
+  else()
+    message(WARNING "Disabling SourceLink due to old version of MSVC. Please update to VS2019!")
+  endif()
+endif()
+
 # Export a JSON file with the compilation commands that external tools can use
 # to analyze the source code of the project.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,10 +71,10 @@ endif()
 # - npm/package.json
 # - hermes-engine.podspec
 project(Hermes
-        VERSION 0.11.0
+        VERSION 0.11.6
         LANGUAGES C CXX)
 # Optional suffix like "rc3"
-set(VERSION_SUFFIX "ms.5")
+set(VERSION_SUFFIX "ms.6")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")
 
@@ -226,6 +226,9 @@ set(HERMESVM_EXCEPTION_ON_OOM OFF CACHE BOOL
 
 set(HERMESVM_PLATFORM_LOGGING OFF CACHE BOOL
     "hermesLog(...) is enabled, using the platform's logging mechanism")
+
+set(HERMESJSI_DISABLE_STATS_TIMER OFF CACHE BOOL
+    "Record timing stats for every JS<->C++ transition")
 
 set(HERMES_RUN_WASM OFF CACHE BOOL
     "Emit Asm.js/Wasm unsafe compiler intrinsics")
@@ -392,6 +395,9 @@ if(HERMESVM_EXCEPTION_ON_OOM)
 endif()
 if(HERMESVM_PLATFORM_LOGGING)
     add_definitions(-DHERMESVM_PLATFORM_LOGGING)
+endif()
+if(HERMESJSI_DISABLE_STATS_TIMER)
+    add_definitions(-DHERMESJSI_DISABLE_STATS_TIMER)
 endif()
 if(HERMES_RUN_WASM)
     add_definitions(-DHERMES_RUN_WASM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,7 +465,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
   endif()
 endif()
 
-if ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
+if ("${CMAKE_C_COMPILER_ID}" MATCHES "MSVC")
   # Enable source linking
   # NOTE: Dependencies are not properly setup here.
   #       Currently, CMake does not know to re-link if SOURCE_LINK_JSON changes

--- a/cmake/modules/GitCommands.cmake
+++ b/cmake/modules/GitCommands.cmake
@@ -1,0 +1,88 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# Copied from https://github.com/microsoft/Azure-Kinect-Sensor-SDK/blob/develop/cmake/GitCommands.cmake
+
+find_package(Git REQUIRED QUIET)
+if (NOT Git_FOUND)
+    message(FATAL_ERROR "Unable to find git, which is needed for versioning")
+endif()
+
+function(get_git_dir DIRECTORY OUTPUT_VAR)
+    execute_process(
+        COMMAND
+            ${GIT_EXECUTABLE} rev-parse --git-dir
+        WORKING_DIRECTORY
+            ${DIRECTORY}
+        RESULT_VARIABLE
+            GIT_DIR_RESULT
+        OUTPUT_VARIABLE
+            GIT_DIR_OUTPUT
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    # Allow to fail
+    set(${OUTPUT_VAR} ${GIT_DIR_OUTPUT} PARENT_SCOPE)
+endfunction()
+
+function(get_git_current_hash DIRECTORY OUTPUT_VAR)
+    execute_process(
+        COMMAND
+            ${GIT_EXECUTABLE} rev-parse --verify HEAD
+        WORKING_DIRECTORY
+            ${DIRECTORY}
+        RESULT_VARIABLE
+            GIT_CURRENT_HASH_RESULT
+        OUTPUT_VARIABLE
+            GIT_CURRENT_HASH_OUTPUT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if (NOT ("${GIT_CURRENT_HASH_RESULT}" STREQUAL "0"))
+        message(${GIT_CURRENT_HASH_OUTPUT})
+        message(FATAL_ERROR "Failed to get ${DIRECTORY} git hash")
+    endif()
+
+    set(${OUTPUT_VAR} ${GIT_CURRENT_HASH_OUTPUT} PARENT_SCOPE)
+endfunction()
+
+function(get_git_remote_url DIRECTORY OUTPUT_VAR)
+    execute_process(
+        COMMAND
+            ${GIT_EXECUTABLE} config --get remote.origin.url
+        RESULT_VARIABLE
+            GIT_REMOTE_URL_RESULT
+        OUTPUT_VARIABLE
+            GIT_REMOTE_URL_OUTPUT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        WORKING_DIRECTORY
+            ${DIRECTORY}
+    )
+
+    if (NOT ("${GIT_REMOTE_URL_RESULT}" STREQUAL "0"))
+        message(${GIT_REMOTE_URL_OUTPUT})
+        message(FATAL_ERROR "Failed to get ${DIRECTORY} git remote")
+    endif()
+
+    set(${OUTPUT_VAR} ${GIT_REMOTE_URL_OUTPUT} PARENT_SCOPE)
+endfunction()
+
+function(run_git_submodule_foreach CMD DIRECTORY OUTPUT_VALUE)
+    execute_process(
+        COMMAND
+            ${GIT_EXECUTABLE} submodule foreach --quiet --recursive "${CMD}"
+        RESULT_VARIABLE
+            GIT_SUBMODULE_CMD_RESULT
+        OUTPUT_VARIABLE
+            GIT_SUBMODULE_CMD_OUTPUT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        WORKING_DIRECTORY
+            ${DIRECTORY}
+    )
+
+    if (NOT ("${GIT_SUBMODULE_CMD_RESULT}" STREQUAL "0"))
+        message(${GIT_SUBMODULE_CMD_OUTPUT})
+        message(FATAL_ERROR "Failed to run git submodule foreach command: ${CMD} in ${DIRECTORY}")
+    endif()
+    set(${OUTPUT_VALUE} ${GIT_SUBMODULE_CMD_OUTPUT} PARENT_SCOPE)
+endfunction()

--- a/cmake/modules/SourceLink.cmake
+++ b/cmake/modules/SourceLink.cmake
@@ -1,0 +1,107 @@
+# Copied from https://github.com/microsoft/Azure-Kinect-Sensor-SDK/blob/develop/cmake/SourceLink.cmake
+# CMake Module to generate Source Link JSON for the MSVC compiler
+#
+# Microsoft defines Source Link as the following:
+#
+# > Source Link is a developer productivity feature that allows unique
+# > information about an assembly's original source code to be embedded in its
+# > PDB during compilation.
+# https://github.com/dotnet/designs/blob/master/accepted/diagnostics/source-link.md
+#
+# Specifically, this script will embedded information into the PDB of where to
+# download the source code from. This will allow developers to use the PDB without
+# the source located on disk.
+#
+# This script currently only works with GitHub but could be extended to support
+# other source control servers. Any server which hosts their code as raw source
+# over HTTP should work.
+#
+include(GitCommands)
+
+# Warn if this is included and the compilier doesn't support source link
+if ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
+    if ("${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER_EQUAL "19.20")
+        # Good to go!
+    elseif("${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER_EQUAL "19.14")
+        message(STATUS "SourceLink enabled but case insensative")
+    else()
+        message(WARNING "SourceLink will not work on version of MSVC less than 19.14")
+    endif()
+else()
+    message(WARNING "SourceLink will not work on the ${CMAKE_C_COMPILER_ID} compiler")
+endif()
+
+# REPO_ROOT is the path to the repository where code it stored.
+#
+# SOURCE_LINK_JSON_PATH is the file to output the json
+function(source_link REPO_ROOT SOURCE_LINK_JSON_PATH)
+    if (NOT (IS_DIRECTORY ${REPO_ROOT}))
+        message(FATAL_ERROR "\"${REPO_ROOT}\" is not a directory")
+    endif()
+
+    get_git_remote_url(${REPO_ROOT} GIT_REMOTE)
+    get_git_current_hash(${REPO_ROOT} GIT_CURRENT_HASH)
+
+    build_source_link_rule(${REPO_ROOT} ${GIT_REMOTE} ${GIT_CURRENT_HASH} ROOT_RULE)
+
+    set(SOURCE_LINK_RULES)
+    list(APPEND SOURCE_LINK_RULES ${ROOT_RULE})
+
+    # Also build rules for submodules
+    run_git_submodule_foreach("echo $displaypath,$sha1,`git config --get remote.origin.url`" ${REPO_ROOT} SUBMODULE_INFO)
+
+    if (NOT ("${SUBMODULE_INFO}" STREQUAL ""))
+        # Turn output of new lines into a CMake list
+        string(REPLACE "\r\n" ";" SUBMODULE_INFO ${SUBMODULE_INFO})
+        string(REPLACE "\n" ";" SUBMODULE_INFO ${SUBMODULE_INFO})
+
+        foreach(ITEM ${SUBMODULE_INFO})
+            # Turn each line into a list of path;hash;url
+            string(REPLACE "," ";" SUBMODULE ${ITEM})
+            list(GET SUBMODULE 0 LOCAL_PATH)
+            list(GET SUBMODULE 1 CURRENT_HASH)
+            list(GET SUBMODULE 2 REMOTE)
+            string(CONCAT LOCAL_PATH "${REPO_ROOT}/" ${LOCAL_PATH})
+            build_source_link_rule(${LOCAL_PATH} ${REMOTE} ${CURRENT_HASH} RULE)
+            list(APPEND SOURCE_LINK_RULES ${RULE})
+        endforeach()
+    endif()
+
+    set(OUTPUT)
+    string(APPEND OUTPUT "{\n")
+    string(APPEND OUTPUT "\"documents\": {\n")
+    string(JOIN ",\n" EXPANDED_RULES ${SOURCE_LINK_RULES})
+    string(APPEND OUTPUT "${EXPANDED_RULES}\n")
+    string(APPEND OUTPUT "}\n")
+    string(APPEND OUTPUT "}\n")
+
+    file(WRITE ${SOURCE_LINK_JSON_PATH} ${OUTPUT})
+
+endfunction()
+
+function(build_source_link_rule LOCAL_PATH GIT_REMOTE GIT_CURRENT_HASH OUTPUT)
+    # Verify local path exists
+    if (NOT (IS_DIRECTORY ${LOCAL_PATH}))
+        message(FATAL_ERROR "${LOCAL_PATH} is not a directory")
+    endif()
+
+    # Change local path to native path
+    file(TO_NATIVE_PATH "${LOCAL_PATH}/*" LOCAL_PATH)
+    # Escape any backslashes for JSON
+    string(REPLACE "\\" "\\\\" LOCAL_PATH ${LOCAL_PATH})
+
+    # Verify this is a GitHub URL
+    # In the future we could support other source servers but currently they
+    # are not supported
+    if (NOT ("${GIT_REMOTE}" MATCHES "https://github\\.com"))
+        message(STATUS "Unable to sourcelink remote: \"${GIT_REMOTE}\". Unknown host")
+        return()
+    endif()
+
+    string(REPLACE ".git" "" RAW_GIT_URL ${GIT_REMOTE})
+    string(REPLACE "github.com" "raw.githubusercontent.com" RAW_GIT_URL ${RAW_GIT_URL})
+    string(CONCAT RAW_GIT_URL ${RAW_GIT_URL} "/${GIT_CURRENT_HASH}/*")
+
+    set(${OUTPUT} "\"${LOCAL_PATH}\" : \"${RAW_GIT_URL}\"" PARENT_SCOPE)
+
+endfunction(build_source_link_rule)

--- a/cmake/modules/SourceLink.cmake
+++ b/cmake/modules/SourceLink.cmake
@@ -18,12 +18,12 @@
 #
 include(GitCommands)
 
-# Warn if this is included and the compilier doesn't support source link
+# Warn if this is included and the compiler doesn't support source link
 if ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
     if ("${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER_EQUAL "19.20")
         # Good to go!
     elseif("${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER_EQUAL "19.14")
-        message(STATUS "SourceLink enabled but case insensative")
+        message(STATUS "SourceLink enabled but case insensitive")
     else()
         message(WARNING "SourceLink will not work on version of MSVC less than 19.14")
     endif()
@@ -104,4 +104,4 @@ function(build_source_link_rule LOCAL_PATH GIT_REMOTE GIT_CURRENT_HASH OUTPUT)
 
     set(${OUTPUT} "\"${LOCAL_PATH}\" : \"${RAW_GIT_URL}\"" PARENT_SCOPE)
 
-endfunction(build_source_link_rule)
+endfunction()

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.11.0-ms.5",
+  "version": "0.11.6-ms.6",
   "scripts": {
     "unpack-builds": "node unpack-builds.js",
     "unpack-builds-dev": "node unpack-builds.js --dev",


### PR DESCRIPTION
- Disable Stats Timer (addresses #92)
- Include revision as part of product version in addition to suffix (addresses #91)
- Include license file in NuGet (addresses #98)
- Add Source Link to linker (addresses #102)

Note: I will cherry-pick this into the main branch as well, but we want to (at least temporarily) rev a RN 0.68-compatible 0.11 NuGet first.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/103)