### PR TITLE
compile based on 0.70 + patch

### DIFF
--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -1079,6 +1079,10 @@ void HermesRuntime::dumpSampledTraceToStream(llvh::raw_ostream &stream) {
   ::hermes::vm::SamplingProfiler::dumpChromeTraceGlobal(stream);
 }
 
+void HermesRuntime::sampledTraceToStreamInDevToolsFormat(std::ostream &stream) {
+  throw jsi::JSINativeException("HermesRuntime::sampledTraceToStreamInDevToolsFormat NYI");
+}
+
 /*static*/ std::unordered_map<std::string, std::vector<std::string>>
 HermesRuntime::getExecutedFunctions() {
   std::unordered_map<

--- a/API/hermes/hermes.h
+++ b/API/hermes/hermes.h
@@ -99,6 +99,10 @@ class HERMES_EXPORT HermesRuntime : public jsi::Runtime {
   /// Dump sampled stack trace to the given stream.
   static void dumpSampledTraceToStream(llvh::raw_ostream &stream);
 
+  /// Serialize the sampled stack to the format expected by DevTools'
+  /// Profiler.stop return type.
+  void sampledTraceToStreamInDevToolsFormat(std::ostream &stream);
+
   /// Return the executed JavaScript function info.
   /// This information holds the segmentID, Virtualoffset and sourceURL.
   /// This information is needed specifically to be able to symbolicate non-CJS

--- a/API/inspector/react-native/CMakeLists.txt
+++ b/API/inspector/react-native/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
   reactnative
   GIT_REPOSITORY https://github.com/facebook/react-native.git
-  GIT_TAG        v0.66.4
+  GIT_TAG        v0.70.0-rc.3
   GIT_SHALLOW    1
   GIT_PROGRESS   1
 )
@@ -36,6 +36,18 @@ if(NOT reactnative_POPULATED)
     "${file_text}"
   )
   file(WRITE ${reactnative_SOURCE_DIR}/ReactCommon/hermes/inspector/chrome/Registration.h "${file_text}")
+
+  # Fix for https://github.com/microsoft/react-native-windows/issues/9662 (pushed in FB RN per
+  # https://github.com/facebook/react-native/pull/34342). This patch is no longer needed and should be 
+  # removed once the GIT_TAG above contains commit ID 60e7eb4d534298cb9888d5ab0c8b6a6b041dc299.
+  file(READ ${reactnative_SOURCE_DIR}/ReactCommon/hermes/inspector/chrome/ConnectionDemux.cpp file_text)
+  string(REGEX REPLACE 
+    "\n([ \t]*)auto conn = conns_\\.at\\(pageId\\);\n[ \t]*conn->disconnect\\(\\);\n"
+    "\n\\1auto conn = conns_.at(pageId);\n\\1std::string title = conn->getTitle();\n\\1inspectedContexts_->erase(title);\n\\1conn->disconnect();\n"
+    file_text
+    "${file_text}"
+  )
+  file(WRITE ${reactnative_SOURCE_DIR}/ReactCommon/hermes/inspector/chrome/ConnectionDemux.cpp  "${file_text}")
 
   file(GLOB_RECURSE YARN_FILES ${reactnative_SOURCE_DIR}/yarn.lock ${reactnative_SOURCE_DIR}/**/yarn.lock)
   message("Removing unused yarn.lock files: ${YARN_FILES}")


### PR DESCRIPTION
## Summary

Updating the version of ReactCommon used within hermes-win to include the fix for [RNW:9662](https://github.com/microsoft/react-native-windows/issues/9662) (pushed to FB RN per [PR:34342](https://github.com/facebook/react-native/pull/34342))

## Test Plan

All *Tests.exe within the hermes-win projects succeed. This is change is requirement to merge [a new test method](https://github.com/aeulitz/react-native-windows/blob/DebugHang/packages/debug-test/DebuggingFeatures.test.ts#L245) into RNW (locally verified).


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/121)