### PR TITLE
update ReactCommon to v0.70.0-rc.3, patch in fix for RNW:9662

### DIFF
--- a/API/inspector/react-native/CMakeLists.txt
+++ b/API/inspector/react-native/CMakeLists.txt
@@ -36,6 +36,18 @@ if(NOT reactnative_POPULATED)
   )
   file(WRITE ${reactnative_SOURCE_DIR}/ReactCommon/hermes/inspector/chrome/Registration.h "${file_text}")
 
+  # Fix for https://github.com/microsoft/react-native-windows/issues/9662 (pushed in FB RN per
+  # https://github.com/facebook/react-native/pull/34342). This patch is no longer needed and should be 
+  # removed once the GIT_TAG above contains commit ID 60e7eb4d534298cb9888d5ab0c8b6a6b041dc299.
+  file(READ ${reactnative_SOURCE_DIR}/ReactCommon/hermes/inspector/chrome/ConnectionDemux.cpp file_text)
+  string(REGEX REPLACE 
+    "\n([ \t]*)auto conn = conns_\\.at\\(pageId\\);\n[ \t]*conn->disconnect\\(\\);\n"
+    "\n\\1auto conn = conns_.at(pageId);\n\\1std::string title = conn->getTitle();\n\\1inspectedContexts_->erase(title);\n\\1conn->disconnect();\n"
+    file_text
+    "${file_text}"
+  )
+  file(WRITE ${reactnative_SOURCE_DIR}/ReactCommon/hermes/inspector/chrome/ConnectionDemux.cpp  "${file_text}")
+
   file(GLOB_RECURSE YARN_FILES ${reactnative_SOURCE_DIR}/yarn.lock ${reactnative_SOURCE_DIR}/**/yarn.lock)
   message("Removing unused yarn.lock files: ${YARN_FILES}")
   if(YARN_FILES)


### PR DESCRIPTION
## Summary
Updating the version of ReactCommon; patching in the fix for [RNW:9662](https://github.com/microsoft/react-native-windows/issues/9662) (pushed to FB RN per [PR:34342](https://github.com/facebook/react-native/pull/34342))

## Test Plan

All *Tests.exe within the hermes-win projects succeed. This change is a requirement to merge [a new test method](https://github.com/aeulitz/react-native-windows/blob/DebugHang/packages/debug-test/DebuggingFeatures.test.ts#L245) into RNW (locally verified).


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/122)