### PR TITLE
Set hermes-windows version to 0.70.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 # - npm/package.json
 # - hermes-engine.podspec
 project(Hermes
-        VERSION 0.12.3
+        VERSION 0.70.0
         LANGUAGES C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.12.2",
+  "version": "0.70.0",
   "scripts": {
     "unpack-builds": "node unpack-builds.js",
     "unpack-builds-dev": "node unpack-builds.js --dev",


### PR DESCRIPTION
## Summary

Set current version of hermes-windows to 0.70.0 to match the corresponding version of react-native.
In future we are going to maintain a release branch per react-native version corresponding to react-native releases.
It is matching the release and branching policy in facebook/hermes and facebook/react-native repos.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/123)