### PR TITLE
Merge rn/0.70-stable hermes branch, bump version to 0.70.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 # - npm/package.json
 # - hermes-engine.podspec
 project(Hermes
-        VERSION 0.70.0
+        VERSION 0.70.1
         LANGUAGES C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")

--- a/lib/Platform/Intl/CMakeLists.txt
+++ b/lib/Platform/Intl/CMakeLists.txt
@@ -20,6 +20,7 @@ if(HERMES_ENABLE_INTL)
     )
     # Work around a bug in unity builds where it tries to build Obj-C as C++.
     set_target_properties(hermesPlatformIntl PROPERTIES UNITY_BUILD false)
+    target_compile_options(hermesPlatformIntl PRIVATE -fobjc-arc)
   else()
     add_hermes_library(hermesPlatformIntl STATIC PlatformIntlDummy.cpp LINK_LIBS hermesPublic)
   endif()

--- a/lib/Platform/Intl/PlatformIntlApple.mm
+++ b/lib/Platform/Intl/PlatformIntlApple.mm
@@ -11,6 +11,8 @@
 #import <Foundation/Foundation.h>
 #include <unordered_set>
 
+static_assert(__has_feature(objc_arc), "arc must be enabled");
+
 namespace hermes {
 namespace platform_intl {
 namespace {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.70.0",
+  "version": "0.70.1",
   "scripts": {
     "unpack-builds": "node unpack-builds.js",
     "unpack-builds-dev": "node unpack-builds.js --dev",


### PR DESCRIPTION
## Summary

This PR is merging the latest code from the rn/0.70-stable hermes branch:

- Merge tag 'hermes-2022-08-16-RNv0.70.0-716d48baf36b0b326ab82f53207b8682c87fc017'
- Bump version to 0.70.1

## Test Plan

The code passes all unit tests

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/118)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/124)