### PR TITLE
Pull facebook/hermes branches nightly

### DIFF
--- a/.ado/update-hermes.yml
+++ b/.ado/update-hermes.yml
@@ -14,7 +14,7 @@ variables:
   - group: Hermes-Windows Secrets
 
 jobs:
-  - job: UpdateMetaMain
+  - job: UpdateMetaBranches
     timeoutInMinutes: 10
     pool: 
       vmImage: ubuntu-latest
@@ -34,5 +34,21 @@ jobs:
           git log -1
         displayName: Get local state to match main commit in facebook/hermes
 
-      - script: git push authenticated HEAD:meta_main --force
-        displayName: Push latest commit to meta_main by force-pushing
+      - script: git push authenticated HEAD:meta/main --force
+        displayName: Push latest commit to meta/main by force-pushing
+        
+      - script: |
+          git reset fb/rn/0.69-stable --hard
+          git log -1
+        displayName: Get local state to match rn/0.69-stable commit in facebook/hermes
+
+      - script: git push authenticated HEAD:meta/rn/0.69-stable --force
+        displayName: Push latest commit to meta/rn/0.69-stable by force-pushing
+
+      - script: |
+          git reset fb/rn/0.70-stable --hard
+          git log -1
+        displayName: Get local state to match rn/0.70-stable commit in facebook/hermes
+
+      - script: git push authenticated HEAD:meta/rn/0.70-stable --force
+        displayName: Push latest commit to meta/rn/0.70-stable by force-pushing

--- a/.ado/update-hermes.yml
+++ b/.ado/update-hermes.yml
@@ -1,0 +1,29 @@
+name: Hermes-Update-$(Date:yyMM.d)$(Rev:rrr)
+
+pr: none
+trigger: none
+schedules:
+  - cron: "0 0 * * *"
+    displayName: Daily midnight Facebook/Hermes ingestion
+    branches:
+      include:
+        - main
+
+jobs:
+  - job: UpdateMetaMain
+    timeoutInMinutes: 10
+    pool: 
+      vmImage: ubuntu-latest
+    displayName: Update Hermes Branch to latest
+    steps:
+      - script: git remote add fb https://github.com/facebook/hermes
+        displayName: Add facebook/hermes as report
+      
+      - script: git fetch fb
+        displayName: Fetch latest facebook commit
+      
+      - script: git reset fb/main --hard
+        displayName: Get local state to latest main commit in facebook org
+
+      - script: git push origin HEAD:meta_main --force
+        displayName: Push latest commit to meta_main by force-pushing

--- a/.ado/update-hermes.yml
+++ b/.ado/update-hermes.yml
@@ -21,7 +21,7 @@ jobs:
     displayName: Update Hermes Branch to latest
     steps:
       - script: git remote add fb https://github.com/facebook/hermes
-        displayName: Add facebook/hermes as report
+        displayName: Add facebook/hermes as remote
       
       - script: git remote add authenticated https://rnbot:$(githubAuthToken)@github.com/microsoft/hermes-windows
         displayName: Add authenticated remote for updates

--- a/.ado/update-hermes.yml
+++ b/.ado/update-hermes.yml
@@ -24,9 +24,9 @@ jobs:
         displayName: Add facebook/hermes as report
       
       - script: git remote add authenticated https://rnbot:$(githubAuthToken)@github.com/microsoft/hermes-windows
-        displayName: Add facebook/hermes as report
+        displayName: Add authenticated remote for updates
 
-      - script: git remotes
+      - script: git remote -v
         displayName: Show remotes
 
       - script: git fetch fb

--- a/.ado/update-hermes.yml
+++ b/.ado/update-hermes.yml
@@ -20,17 +20,22 @@ jobs:
       vmImage: ubuntu-latest
     displayName: Update Hermes Branch to latest
     steps:
-      - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
-        persistCredentials: true
-
       - script: git remote add fb https://github.com/facebook/hermes
         displayName: Add facebook/hermes as report
       
+      - script: git remote add authenticated https://rnbot:$(githubAuthToken)@github.com/microsoft/hermes-windows
+        displayName: Add facebook/hermes as report
+
+      - script: git remotes
+        displayName: Show remotes
+
       - script: git fetch fb
         displayName: Fetch all latest facebook/hermes commits
       
-      - script: git reset fb/main --hard
+      - script: |
+          git reset fb/main --hard
+          git log -1
         displayName: Get local state to match main commit in facebook/hermes
 
-      - script: git push origin HEAD:meta_main --force
+      - script: git push authenticated HEAD:meta_main --force
         displayName: Push latest commit to meta_main by force-pushing

--- a/.ado/update-hermes.yml
+++ b/.ado/update-hermes.yml
@@ -8,6 +8,10 @@ schedules:
     branches:
       include:
         - main
+# githubAuthToken
+
+variables:
+  - group: Hermes-Windows Secrets
 
 jobs:
   - job: UpdateMetaMain
@@ -16,14 +20,17 @@ jobs:
       vmImage: ubuntu-latest
     displayName: Update Hermes Branch to latest
     steps:
+      - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+        persistCredentials: true
+
       - script: git remote add fb https://github.com/facebook/hermes
         displayName: Add facebook/hermes as report
       
       - script: git fetch fb
-        displayName: Fetch latest facebook commit
+        displayName: Fetch all latest facebook/hermes commits
       
       - script: git reset fb/main --hard
-        displayName: Get local state to latest main commit in facebook org
+        displayName: Get local state to match main commit in facebook/hermes
 
       - script: git push origin HEAD:meta_main --force
         displayName: Push latest commit to meta_main by force-pushing

--- a/.ado/update-hermes.yml
+++ b/.ado/update-hermes.yml
@@ -26,9 +26,6 @@ jobs:
       - script: git remote add authenticated https://rnbot:$(githubAuthToken)@github.com/microsoft/hermes-windows
         displayName: Add authenticated remote for updates
 
-      - script: git remote -v
-        displayName: Show remotes
-
       - script: git fetch fb
         displayName: Fetch all latest facebook/hermes commits
       


### PR DESCRIPTION
This PR adds new update-hermes.yml ADO jobs that are going to pull `hermes` branches from https://github.com/facebook/hermes into our https://github.com/microsoft/hermes-windows repo:
- main-> meta/main
- rn/0.69-stable -> meta/rn/0.69-stable
- rn/0.70-stable -> meta/rn/0.70-stable

These branches are going to be full copies of the corresponding branches in facebook/hermes repo without any additional changes. The eventual goal is to implement automated merging of facebook/hermes changes into our microsoft/hermes-windows branches. The plan is that we are going to merge changes from the copy branches into our branches. It should allow us to see the full history of all changes.

The script is originally created by @dannyvv.