### PR TITLE
Split out rnw/0.70-stable branch

### DIFF
--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -4,6 +4,7 @@ trigger: none
 pr:
   - main
   - temp/v0.11
+  - rnw/0.70-stable
 
 pool:
   vmImage: 'windows-latest'

--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -4,7 +4,7 @@ trigger: none
 pr:
   - main
   - temp/v0.11
-  - rnw/0.70-stable
+  - rnw/*
 
 pool:
   vmImage: 'windows-latest'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 # - npm/package.json
 # - hermes-engine.podspec
 project(Hermes
-        VERSION 0.70.1
+        VERSION 0.71.0.20220829
         LANGUAGES C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.70.1",
+  "version": "0.71.0.20220829",
   "scripts": {
     "unpack-builds": "node unpack-builds.js",
     "unpack-builds-dev": "node unpack-builds.js --dev",


### PR DESCRIPTION
The facebook/hermes repo creates release branches to match ReactNative versions. E.g. `rn/0.69-stable` and `rn/0.70-stable`.
In this PR we mimic the same behavior to match RN for Windows versions:
- Releases for RNW 0.70 are going to be from the rnw/0.70-stable branch
- The main branch releases are going to be 0.71.x where the x is the current date. E.g. 20220929. When we cut the new 0.71-stable branch we will start to use versions 0.71.1, 0.71.2, etc, and then we will start to use 0.72.x versions and so on.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/126)