### PR TITLE
Fix CMake build that uses VS 2022

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 # - npm/package.json
 # - hermes-engine.podspec
 project(Hermes
-        VERSION 0.71.0.20220906
+        VERSION 0.71.0.20220908
         LANGUAGES C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.71.0.20220906",
+  "version": "0.71.0.20220908",
   "scripts": {
     "unpack-builds": "node unpack-builds.js",
     "unpack-builds-dev": "node unpack-builds.js --dev",

--- a/unittests/NAPI/js/CMakeLists.txt
+++ b/unittests/NAPI/js/CMakeLists.txt
@@ -43,23 +43,25 @@ set(testJSFiles
   test_typedarray/test.js
 )
 
+if(WIN32)
+  # "npx" interrupts current shell script execution without the "call"
+  set(npx "call" "npx")
+  set(yarn "call" "yarn")
+else()
+  set(npx "npx")
+  set(yarn "yarn")
+endif()
+
 # run "yarn install"
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/node_modules.md5
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/yarn.lock
-  COMMAND yarn install --frozen-lockfile
+  COMMAND ${yarn} install --frozen-lockfile
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 add_custom_target(installNapiTestJsTools
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/node_modules.md5
 )
-
-if(WIN32)
-  # "npx" interrupts current shell script execution without the "call"
-  set(npx "call" "npx")
-else()
-  set(npx "npx")
-endif()
 
 # add the Babel transform commands for each test JS file
 foreach(testJSFile ${testJSFiles})


### PR DESCRIPTION
## Summary

When CMake uses VS 2022 to compile code we see issues with installing npm packages using yarn.
The issue is fixed by calling `yarn` using the `call` command.
We previously did the same trick with the `npx` command.

## Test Plan

All unit tests are passing.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/129)