### PR TITLE
Fix setting `/guard:cf` for tests

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -92,6 +92,9 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
   # Generate PDBs
   set(compile_flags "${compile_flags} /Zi")
 
+  # Security flags
+  set(compile_flags "${compile_flags} /guard:cf /Qspectre /sdl /ZH:SHA_256")
+
   set(link_flags_debug "/DEBUG")
   # Use /OPT:NOICF because hermes associates function pointer with its name.
   # The optimization that merges functions with the same body breaks that code.

--- a/API/inspector/CMakeLists.txt
+++ b/API/inspector/CMakeLists.txt
@@ -131,6 +131,9 @@ set(compile_flags "${compile_flags} /GR")
 # Generate PDBs
 set(compile_flags "${compile_flags} /Zi")
 
+# Security flags
+set(compile_flags "${compile_flags} /guard:cf /Qspectre /sdl /ZH:SHA_256")
+
 set(link_flags_debug "/DEBUG")
 set(link_flags_release "/DEBUG;/OPT:REF;/OPT:ICF;/INCREMENTAL:NO")
 if(CMAKE_VS_PLATFORM_NAME MATCHES "^(x64|x86|Win32)$")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 # - npm/package.json
 # - hermes-engine.podspec
 project(Hermes
-        VERSION 0.71.0.20220908
+        VERSION 0.71.0.20220909
         LANGUAGES C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")

--- a/cmake/modules/Hermes.cmake
+++ b/cmake/modules/Hermes.cmake
@@ -124,6 +124,10 @@ function(hermes_update_compile_flags name)
     endif ()
   endif ()
 
+  if (MSVC)
+    set(flags "${flags} /guard:cf /Qspectre /sdl /ZH:SHA_256")
+  endif()
+
   if (update_src_props)
     foreach (fn ${sources})
       get_filename_component(suf ${fn} EXT)
@@ -281,8 +285,6 @@ if (MSVC)
   # Note: Security warnings need to be fixed / baselined to be sdl clean - 4146, 4244 and 4267 (currently disabled)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DYNAMICBASE /guard:cf")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DYNAMICBASE /guard:cf")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /guard:cf /Qspectre /sdl /ZH:SHA_256")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /guard:cf /Qspectre /sdl /ZH:SHA_256")
 
   # Tell MSVC to use the Unicode version of the Win32 APIs instead of ANSI.
   #    add_definitions(

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.71.0.20220908",
+  "version": "0.71.0.20220909",
   "scripts": {
     "unpack-builds": "node unpack-builds.js",
     "unpack-builds-dev": "node unpack-builds.js --dev",


### PR DESCRIPTION
## Summary

Some of the Hermes unit tests are failing with the error:
```
Exception has occurred: W32/0xC0000409
Unhandled exception at 0x00007FF8231D2240 (ntdll.dll) in HermesBCGenTests.exe: Indirect call guard check detected invalid 
```

The investigation has shown that some libraries miss `/guard:cf` settings and the `hermes::vm::Buffer` implementation is spread between different libraries.

In this PR we fix the issue by changing the way we are setting the `/guard:cf` flag and other security related flags.

After this change our `hermes.dll` and `hermesinspector.dll` have no `BinSkim` issues besides three disabled warnings.

## Test Plan

All unit tests are passing.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/130)