### PR TITLE
execution context ID in Debugger.scriptParsed

### DIFF
--- a/API/inspector/react-native/CMakeLists.txt
+++ b/API/inspector/react-native/CMakeLists.txt
@@ -48,6 +48,17 @@ if(NOT reactnative_POPULATED)
   )
   file(WRITE ${reactnative_SOURCE_DIR}/ReactCommon/hermes/inspector/chrome/ConnectionDemux.cpp  "${file_text}")
 
+  # Fix for https://github.com/facebook/react-native/issues/34639 (pushed to FB RN per
+  # https://github.com/facebook/react-native/pull/34640).
+  file(READ ${reactnative_SOURCE_DIR}/ReactCommon/hermes/inspector/chrome/Connection.cpp file_text)
+  string(REGEX REPLACE 
+    "\n([ \t]*)// TODO\\(jpporto\\): fix test cases sending invalid context id.\n[ \t]*// note.executionContextId = kHermesExecutionContextId;"
+    "\n\\1note.executionContextId = kHermesExecutionContextId;"
+    file_text
+    "${file_text}"
+  )
+  file(WRITE ${reactnative_SOURCE_DIR}/ReactCommon/hermes/inspector/chrome/Connection.cpp "${file_text}")
+
   file(GLOB_RECURSE YARN_FILES ${reactnative_SOURCE_DIR}/yarn.lock ${reactnative_SOURCE_DIR}/**/yarn.lock)
   message("Removing unused yarn.lock files: ${YARN_FILES}")
   if(YARN_FILES)


### PR DESCRIPTION
## Summary

As generated by ReactCommon code, the CDP [Debugger.scriptParsed](https://chromedevtools.github.io/devtools-protocol/tot/Debugger/#event-scriptParsed) event carries a zero execution context ID. It should match the execution context ID contained in the argument of the [Runtime.executionContextCreated](https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#event-executionContextCreated) event. Tracking issue is RN:34639](https://github.com/facebook/react-native/issues/34639).

I'm attempting to push the actual fix to FB RN per [PR:34640](https://github.com/facebook/react-native/pull/34640). This change brings the same fix into hermes-windows via patch.

## Test Plan

I verified via packet tracers (Wireshark, Chrome DevTools protocol monitor) that Debugger.scriptParsed carries the correct execution context ID.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/131)