### PR TITLE
Suppress CG during Setup Pipeline Job.

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -24,6 +24,10 @@ variables:
 
 jobs:
   - job: Setup
+    variables:
+      # Component Governance is ran as part of the Build Job.
+      - name: "skipComponentGovernanceDetection"
+        value: "true"
     steps:
       - script: node .ado/scripts/setVersionNumber.js
         name: setVersions


### PR DESCRIPTION
Component governance is run during the Build job already, but Azure is still auto injecting it into the Setup job. This PR suppresses this behavior.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/139)