### PR TITLE
Remove unused Gemfile.lock from RN source prior to building.

### DIFF
--- a/API/inspector/react-native/CMakeLists.txt
+++ b/API/inspector/react-native/CMakeLists.txt
@@ -64,6 +64,12 @@ if(NOT reactnative_POPULATED)
   if(YARN_FILES)
     file(REMOVE ${YARN_FILES})
   endif()
+
+  file(GLOB_RECURSE GEMFILES ${reactnative_SOURCE_DIR}/Gemfile.lock ${reactnative_SOURCE_DIR}/**/Gemfile.lock)
+  message("Removing unused Gemfile.lock files: ${GEMFILES}")
+  if(GEMFILES)
+    file(REMOVE ${GEMFILES})
+  endif()
 endif()
 
 set(REACT_NATIVE_SOURCE ${reactnative_SOURCE_DIR} PARENT_SCOPE)


### PR DESCRIPTION
We do not use the Gemfile.lock within react native source code, and it is causing component governance alerts to be opened. This PR remediates this by removing said lock file prior to building.