### PR TITLE
Add Hermes ABI-safe API

### DIFF
--- a/API/hermes/hermes_napi.cpp
+++ b/API/hermes/hermes_napi.cpp
@@ -4191,7 +4191,7 @@ napi_status NapiEnvironment::getProperty(
     napi_value key,
     napi_value *result) noexcept {
   CHECK_NAPI(checkPendingJSError());
-  NapiHandleScope scope{*this};
+  NapiHandleScope scope{*this, result};
   CHECK_ARG(key);
   napi_value objValue;
   CHECK_NAPI(coerceToObject(object, &objValue));
@@ -6222,7 +6222,7 @@ napi_status NapiEnvironment::serializeScript(
           napiEnv(this),
           napi_ext_buffer{
               buffer.release(),
-              sourceSize + 1,
+              sourceSize,
               [](napi_env /*env*/, void *data, void * /*finalizeHint*/) {
                 std::unique_ptr<char[]> buf(reinterpret_cast<char *>(data));
               },

--- a/API/hermes/hermes_win.cpp
+++ b/API/hermes/hermes_win.cpp
@@ -15,6 +15,16 @@
 
 #include <werapi.h>
 
+#define CHECKED_RUNTIME(runtime) \
+  (runtime == nullptr)           \
+      ? hermes_error             \
+      : reinterpret_cast<facebook::hermes::RuntimeWrapper *>(runtime)
+
+#define CHECK_ARG(arg)   \
+  if (arg == nullptr) {  \
+    return hermes_error; \
+  }
+
 namespace facebook::hermes {
 
 // Forward declaration
@@ -170,4 +180,86 @@ void hermesCrashHandler(HermesRuntime &runtime, int fd) {
   json.endJSONL();
 }
 
+class RuntimeWrapper {
+ public:
+  explicit RuntimeWrapper(bool withWER = false)
+      : hermesRuntime_(
+            withWER ? makeHermesRuntimeWithWER() : makeHermesRuntime()) {}
+
+  hermes_status getNonAbiSafeRuntime(void **nonAbiSafeRuntime) {
+    CHECK_ARG(nonAbiSafeRuntime);
+    *nonAbiSafeRuntime = hermesRuntime_.get();
+    return hermes_ok;
+  }
+
+  hermes_status dumpCrashData(int32_t fd) {
+    hermesCrashHandler(*hermesRuntime_, fd);
+    return hermes_ok;
+  }
+
+  hermes_status addToProfiler() {
+    hermesRuntime_->registerForProfiling();
+    return hermes_ok;
+  }
+
+  hermes_status removeFromProfiler() {
+    hermesRuntime_->unregisterForProfiling();
+    return hermes_ok;
+  }
+
+ private:
+  std::unique_ptr<HermesRuntime> hermesRuntime_;
+};
+
 } // namespace facebook::hermes
+
+hermes_status hermes_create_runtime(hermes_runtime *runtime) {
+  CHECK_ARG(runtime);
+  *runtime =
+      reinterpret_cast<hermes_runtime>(new facebook::hermes::RuntimeWrapper());
+  return hermes_ok;
+}
+
+hermes_status hermes_create_runtime_with_wer(hermes_runtime *runtime) {
+  CHECK_ARG(runtime);
+  *runtime = reinterpret_cast<hermes_runtime>(
+      new facebook::hermes::RuntimeWrapper(/*withWER*/ true));
+  return hermes_ok;
+}
+
+hermes_status hermes_delete_runtime(hermes_runtime runtime) {
+  return hermes_ok;
+}
+
+hermes_status hermes_get_non_abi_safe_runtime(
+    hermes_runtime runtime,
+    void **non_abi_safe_runtime) {
+  return CHECKED_RUNTIME(runtime)->getNonAbiSafeRuntime(non_abi_safe_runtime);
+}
+
+hermes_status hermes_dump_crash_data(hermes_runtime runtime, int32_t fd) {
+  return CHECKED_RUNTIME(runtime)->dumpCrashData(fd);
+}
+
+hermes_status hermes_sampling_profiler_enable() {
+  facebook::hermes::HermesRuntime::enableSamplingProfiler();
+  return hermes_ok;
+}
+
+hermes_status hermes_sampling_profiler_disable() {
+  facebook::hermes::HermesRuntime::disableSamplingProfiler();
+  return hermes_ok;
+}
+
+hermes_status hermes_sampling_profiler_add(hermes_runtime runtime) {
+  return CHECKED_RUNTIME(runtime)->addToProfiler();
+}
+
+hermes_status hermes_sampling_profiler_remove(hermes_runtime runtime) {
+  return CHECKED_RUNTIME(runtime)->removeFromProfiler();
+}
+
+hermes_status hermes_sampling_profiler_dump_to_file(const char *filename) {
+  facebook::hermes::HermesRuntime::dumpSampledTraceToFile(filename);
+  return hermes_ok;
+}

--- a/API/hermes/hermes_win.h
+++ b/API/hermes/hermes_win.h
@@ -17,4 +17,46 @@ HERMES_EXPORT void __cdecl hermesCrashHandler(HermesRuntime &runtime, int fd);
 
 } // namespace facebook::hermes
 
+#if _M_IX86
+#define HERMES_CDECL __cdecl
+#else
+#define HERMES_CDECL
+#endif
+
+#define HERMES_API HERMES_EXPORT hermes_status HERMES_CDECL
+
+#ifdef __cplusplus
+#define HERMES_EXTERN_C_BEGIN extern "C" {
+#define HERMES_EXTERN_C_END }
+#else
+#define HERMES_EXTERN_C_BEGIN
+#define HERMES_EXTERN_C_END
+#endif
+
+enum hermes_status {
+  hermes_ok,
+  hermes_error,
+};
+
+typedef struct hermes_runtime_s *hermes_runtime;
+
+HERMES_EXTERN_C_BEGIN
+
+HERMES_API hermes_create_runtime(hermes_runtime *runtime);
+HERMES_API hermes_create_runtime_with_wer(hermes_runtime *runtime);
+HERMES_API hermes_delete_runtime(hermes_runtime runtime);
+HERMES_API hermes_get_non_abi_safe_runtime(
+    hermes_runtime runtime,
+    void **non_abi_safe_runtime);
+
+HERMES_API hermes_dump_crash_data(hermes_runtime runtime, int32_t fd);
+
+HERMES_API hermes_sampling_profiler_enable();
+HERMES_API hermes_sampling_profiler_disable();
+HERMES_API hermes_sampling_profiler_add(hermes_runtime runtime);
+HERMES_API hermes_sampling_profiler_remove(hermes_runtime runtime);
+HERMES_API hermes_sampling_profiler_dump_to_file(const char *filename);
+
+HERMES_EXTERN_C_END
+
 #endif // HERMES_HERMES_WIN_H


### PR DESCRIPTION
## Summary

In this PR we start adding Hermes ABI-safe API.

## Details

The following functions are added to ensure proper Hermes runtime instantiation and to enable sampling profiler in ReactNative for Windows.
The new API does not cover the whole API surface yet. It even provides a function `hermes_get_non_abi_safe_runtime` to access non-ABI safe API until we have the full API coverage. The goal is to increase the ABI-safe surface until we can avoid using the non-ABI safe APIs.

The PR also contains fixes to the Node-API implementation which are required for JSI implementation on top of Node-API to pass JSI unit tests.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/hermes-windows/pulls/151)