### PR TITLE
Implement JSI version support.

### DIFF
--- a/API/hermes/TimerStats.cpp
+++ b/API/hermes/TimerStats.cpp
@@ -263,10 +263,12 @@ class TimedRuntime final : public jsi::RuntimeDecorator<jsi::Runtime> {
     return RD::callAsConstructor(func, args, count);
   }
 
+#if JSI_VERSION >= 4
   bool drainMicrotasks(int maxMicrotasksHint) override {
     auto timer = rts_.incomingTimer("drainMicrotasks");
     return RD::drainMicrotasks(maxMicrotasksHint);
   }
+#endif
   /// @}
 
  private:

--- a/API/hermes/TraceInterpreter.cpp
+++ b/API/hermes/TraceInterpreter.cpp
@@ -370,8 +370,11 @@ Value traceValueToJSIValue(
   if (value.isBool()) {
     return Value(value.getBool());
   }
-  if (value.isObject() || value.isBigInt() || value.isString() ||
-      value.isSymbol()) {
+  if (value.isObject() ||
+#if JSI_VERSION >= 8
+      value.isBigInt() ||
+#endif
+      value.isString() || value.isSymbol()) {
     return getJSIValueForUse(value.getUID());
   }
   llvm_unreachable("Unrecognized value type encountered");
@@ -1022,8 +1025,11 @@ Value TraceInterpreter::execFunction(
         // Satisfiable locally
         Value val{rt_, it->second};
         assert(
-            val.isObject() || val.isBigInt() || val.isString() ||
-            val.isSymbol());
+            val.isObject() ||
+#if JSI_VERSION >= 8
+            val.isBigInt() ||
+#endif
+            val.isString() || val.isSymbol());
         // If it was the last local use, delete that object id from locals.
         auto defAndUse = call.locals.find(obj);
         if (defAndUse != call.locals.end() &&
@@ -1166,6 +1172,7 @@ Value TraceInterpreter::execFunction(
             break;
           }
           case RecordType::CreateBigInt: {
+#if JSI_VERSION >= 8
             const auto &cbr =
                 static_cast<const SynthTrace::CreateBigIntRecord &>(*rec);
             Value bigint;
@@ -1184,9 +1191,13 @@ Value TraceInterpreter::execFunction(
             }
             addJSIValueToDefs(
                 call, cbr.objID_, globalRecordNum, std::move(bigint), locals);
+#else
+            throw std::runtime_error("jsi::BigInt is not supported");
+#endif
             break;
           }
           case RecordType::BigIntToString: {
+#if JSI_VERSION >= 8
             const auto &bts =
                 static_cast<const SynthTrace::BigIntToStringRecord &>(*rec);
             BigInt obj = getJSIValueForUse(bts.bigintID_).asBigInt(rt_);
@@ -1196,6 +1207,9 @@ Value TraceInterpreter::execFunction(
                 globalRecordNum,
                 obj.toString(rt_, bts.radix_),
                 locals);
+#else
+            throw std::runtime_error("jsi::BigInt is not supported");
+#endif
             break;
           }
           case RecordType::CreateString: {
@@ -1234,7 +1248,12 @@ Value TraceInterpreter::execFunction(
                   auto val = traceValueToJSIValue(
                       rt_, trace_, getJSIValueForUse, cpnr.traceValue_);
                   if (val.isSymbol())
+#if JSI_VERSION >= 5
                     return PropNameID::forSymbol(rt_, val.getSymbol(rt_));
+#else
+                    throw std::runtime_error(
+                        "PropNameID::forSymbol is not supported");
+#endif
                   return PropNameID::forString(rt_, val.getString(rt_));
                 }
               }
@@ -1284,9 +1303,13 @@ Value TraceInterpreter::execFunction(
             break;
           }
           case RecordType::DrainMicrotasks: {
+#if JSI_VERSION >= 4
             const auto &drainRecord =
                 static_cast<const SynthTrace::DrainMicrotasksRecord &>(*rec);
             rt_.drainMicrotasks(drainRecord.maxMicrotasksHint_);
+#else
+            throw std::runtime_error("drainMicrotasks is not supported");
+#endif
             break;
           }
           case RecordType::GetProperty: {

--- a/API/hermes/TracingRuntime.h
+++ b/API/hermes/TracingRuntime.h
@@ -29,7 +29,9 @@ class TracingRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
       std::unique_ptr<llvh::raw_ostream> traceStream);
 
   virtual SynthTrace::ObjectID getUniqueID(const jsi::Object &o) = 0;
+#if JSI_VERSION >= 8
   virtual SynthTrace::ObjectID getUniqueID(const jsi::BigInt &s) = 0;
+#endif
   virtual SynthTrace::ObjectID getUniqueID(const jsi::String &s) = 0;
   virtual SynthTrace::ObjectID getUniqueID(const jsi::PropNameID &pni) = 0;
   virtual SynthTrace::ObjectID getUniqueID(const jsi::Symbol &sym) = 0;
@@ -43,7 +45,9 @@ class TracingRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
       const std::shared_ptr<const jsi::Buffer> &buffer,
       const std::string &sourceURL) override;
 
+#if JSI_VERSION >= 4
   bool drainMicrotasks(int maxMicrotasksHint = -1) override;
+#endif
 
   jsi::Object createObject() override;
   jsi::Object createObject(std::shared_ptr<jsi::HostObject> ho) override;
@@ -51,9 +55,11 @@ class TracingRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
   // Note that the NativeState methods do not need to be traced since they
   // cannot be observed in JS.
 
+#if JSI_VERSION >= 8
   jsi::BigInt createBigIntFromInt64(int64_t value) override;
   jsi::BigInt createBigIntFromUint64(uint64_t value) override;
   jsi::String bigintToString(const jsi::BigInt &bigint, int radix) override;
+#endif
 
   jsi::String createStringFromAscii(const char *str, size_t length) override;
   jsi::String createStringFromUtf8(const uint8_t *utf8, size_t length) override;
@@ -63,7 +69,9 @@ class TracingRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
   jsi::PropNameID createPropNameIDFromUtf8(const uint8_t *utf8, size_t length)
       override;
   jsi::PropNameID createPropNameIDFromString(const jsi::String &str) override;
+#if JSI_VERSION >= 5
   jsi::PropNameID createPropNameIDFromSymbol(const jsi::Symbol &sym) override;
+#endif
 
   jsi::Value getProperty(const jsi::Object &obj, const jsi::String &name)
       override;
@@ -75,11 +83,11 @@ class TracingRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
       override;
 
   void setPropertyValue(
-      const jsi::Object &obj,
+      JSI_CONST_10 jsi::Object &obj,
       const jsi::String &name,
       const jsi::Value &value) override;
   void setPropertyValue(
-      const jsi::Object &obj,
+      JSI_CONST_10 jsi::Object &obj,
       const jsi::PropNameID &name,
       const jsi::Value &value) override;
 
@@ -87,12 +95,14 @@ class TracingRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
 
   jsi::WeakObject createWeakObject(const jsi::Object &o) override;
 
-  jsi::Value lockWeakObject(const jsi::WeakObject &wo) override;
+  jsi::Value lockWeakObject(
+      JSI_NO_CONST_3 JSI_CONST_10 jsi::WeakObject &wo) override;
 
   jsi::Array createArray(size_t length) override;
+#if JSI_VERSION >= 9
   jsi::ArrayBuffer createArrayBuffer(
       std::shared_ptr<jsi::MutableBuffer> buffer) override;
-
+#endif
   size_t size(const jsi::Array &arr) override;
   size_t size(const jsi::ArrayBuffer &buf) override;
 
@@ -101,7 +111,7 @@ class TracingRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
   jsi::Value getValueAtIndex(const jsi::Array &arr, size_t i) override;
 
   void setValueAtIndexImpl(
-      const jsi::Array &arr,
+      JSI_CONST_10 jsi::Array &arr,
       size_t i,
       const jsi::Value &value) override;
 
@@ -188,9 +198,11 @@ class TracingHermesRuntime final : public TracingRuntime {
   SynthTrace::ObjectID getUniqueID(const jsi::Object &o) override {
     return static_cast<SynthTrace::ObjectID>(hermesRuntime().getUniqueID(o));
   }
+#if JSI_VERSION >= 8
   SynthTrace::ObjectID getUniqueID(const jsi::BigInt &b) override {
     return static_cast<SynthTrace::ObjectID>(hermesRuntime().getUniqueID(b));
   }
+#endif
   SynthTrace::ObjectID getUniqueID(const jsi::String &s) override {
     return static_cast<SynthTrace::ObjectID>(hermesRuntime().getUniqueID(s));
   }

--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -515,8 +515,11 @@ class HermesRuntimeImpl final : public HermesRuntime,
     } else if (value.isNumber()) {
       return vm::HermesValue::encodeUntrustedDoubleValue(value.getNumber());
     } else if (
-        value.isSymbol() || value.isBigInt() || value.isString() ||
-        value.isObject()) {
+        value.isSymbol() ||
+#if JSI_VERSION >= 6
+        value.isBigInt() ||
+#endif
+        value.isString() || value.isObject()) {
       return phv(value);
     } else {
       llvm_unreachable("unknown value kind");
@@ -534,8 +537,11 @@ class HermesRuntimeImpl final : public HermesRuntime,
       return runtime_.makeHandle(
           vm::HermesValue::encodeUntrustedDoubleValue(value.getNumber()));
     } else if (
-        value.isSymbol() || value.isBigInt() || value.isString() ||
-        value.isObject()) {
+        value.isSymbol() ||
+#if JSI_VERSION >= 6
+        value.isBigInt() ||
+#endif
+        value.isString() || value.isObject()) {
       return vm::Handle<vm::HermesValue>(&phv(value));
     } else {
       llvm_unreachable("unknown value kind");
@@ -553,8 +559,10 @@ class HermesRuntimeImpl final : public HermesRuntime,
       return hv.getDouble();
     } else if (hv.isSymbol()) {
       return add<jsi::Symbol>(hv);
+#if JSI_VERSION >= 6
     } else if (hv.isBigInt()) {
       return add<jsi::BigInt>(hv);
+#endif
     } else if (hv.isString()) {
       return add<jsi::String>(hv);
     } else if (hv.isObject()) {
@@ -580,7 +588,9 @@ class HermesRuntimeImpl final : public HermesRuntime,
   jsi::Value evaluateJavaScript(
       const std::shared_ptr<const jsi::Buffer> &buffer,
       const std::string &sourceURL) override;
+#if JSI_VERSION >= 4
   bool drainMicrotasks(int maxMicrotasksHint = -1) override;
+#endif
   jsi::Object global() override;
 
   std::string description() override;
@@ -588,7 +598,9 @@ class HermesRuntimeImpl final : public HermesRuntime,
   jsi::Instrumentation &instrumentation() override;
 
   PointerValue *cloneSymbol(const Runtime::PointerValue *pv) override;
+#if JSI_VERSION >= 6
   PointerValue *cloneBigInt(const Runtime::PointerValue *pv) override;
+#endif
   PointerValue *cloneString(const Runtime::PointerValue *pv) override;
   PointerValue *cloneObject(const Runtime::PointerValue *pv) override;
   PointerValue *clonePropNameID(const Runtime::PointerValue *pv) override;
@@ -598,46 +610,56 @@ class HermesRuntimeImpl final : public HermesRuntime,
   jsi::PropNameID createPropNameIDFromUtf8(const uint8_t *utf8, size_t length)
       override;
   jsi::PropNameID createPropNameIDFromString(const jsi::String &str) override;
+#if JSI_VERSION >= 5
   jsi::PropNameID createPropNameIDFromSymbol(const jsi::Symbol &sym) override;
+#endif
   std::string utf8(const jsi::PropNameID &) override;
   bool compare(const jsi::PropNameID &, const jsi::PropNameID &) override;
 
   std::string symbolToString(const jsi::Symbol &) override;
 
+#if JSI_VERSION >= 8
   jsi::BigInt createBigIntFromInt64(int64_t) override;
   jsi::BigInt createBigIntFromUint64(uint64_t) override;
   bool bigintIsInt64(const jsi::BigInt &) override;
   bool bigintIsUint64(const jsi::BigInt &) override;
   uint64_t truncate(const jsi::BigInt &) override;
   jsi::String bigintToString(const jsi::BigInt &, int) override;
+#endif
 
   jsi::String createStringFromAscii(const char *str, size_t length) override;
   jsi::String createStringFromUtf8(const uint8_t *utf8, size_t length) override;
   std::string utf8(const jsi::String &) override;
 
+#if JSI_VERSION >= 2
   jsi::Value createValueFromJsonUtf8(const uint8_t *json, size_t length)
       override;
+#endif
 
   jsi::Object createObject() override;
   jsi::Object createObject(std::shared_ptr<jsi::HostObject> ho) override;
   std::shared_ptr<jsi::HostObject> getHostObject(const jsi::Object &) override;
   jsi::HostFunctionType &getHostFunction(const jsi::Function &) override;
+
+#if JSI_VERSION >= 7
   bool hasNativeState(const jsi::Object &) override;
   std::shared_ptr<jsi::NativeState> getNativeState(
       const jsi::Object &) override;
   void setNativeState(const jsi::Object &, std::shared_ptr<jsi::NativeState>)
       override;
+#endif
+
   jsi::Value getProperty(const jsi::Object &, const jsi::PropNameID &name)
       override;
   jsi::Value getProperty(const jsi::Object &, const jsi::String &name) override;
   bool hasProperty(const jsi::Object &, const jsi::PropNameID &name) override;
   bool hasProperty(const jsi::Object &, const jsi::String &name) override;
   void setPropertyValue(
-      const jsi::Object &,
+      JSI_CONST_10 jsi::Object &,
       const jsi::PropNameID &name,
       const jsi::Value &value) override;
   void setPropertyValue(
-      const jsi::Object &,
+      JSI_CONST_10 jsi::Object &,
       const jsi::String &name,
       const jsi::Value &value) override;
   bool isArray(const jsi::Object &) const override;
@@ -648,17 +670,20 @@ class HermesRuntimeImpl final : public HermesRuntime,
   jsi::Array getPropertyNames(const jsi::Object &) override;
 
   jsi::WeakObject createWeakObject(const jsi::Object &) override;
-  jsi::Value lockWeakObject(const jsi::WeakObject &) override;
+  jsi::Value lockWeakObject(
+      JSI_NO_CONST_3 JSI_CONST_10 jsi::WeakObject &wo) override;
 
   jsi::Array createArray(size_t length) override;
+#if JSI_VERSION >= 9
   jsi::ArrayBuffer createArrayBuffer(
       std::shared_ptr<jsi::MutableBuffer> buffer) override;
+#endif
   size_t size(const jsi::Array &) override;
   size_t size(const jsi::ArrayBuffer &) override;
   uint8_t *data(const jsi::ArrayBuffer &) override;
   jsi::Value getValueAtIndex(const jsi::Array &, size_t i) override;
   void setValueAtIndexImpl(
-      const jsi::Array &,
+      JSI_CONST_10 jsi::Array &,
       size_t i,
       const jsi::Value &value) override;
 
@@ -677,7 +702,9 @@ class HermesRuntimeImpl final : public HermesRuntime,
       size_t count) override;
 
   bool strictEquals(const jsi::Symbol &a, const jsi::Symbol &b) const override;
+#if JSI_VERSION >= 6
   bool strictEquals(const jsi::BigInt &a, const jsi::BigInt &b) const override;
+#endif
   bool strictEquals(const jsi::String &a, const jsi::String &b) const override;
   bool strictEquals(const jsi::Object &a, const jsi::Object &b) const override;
 
@@ -1208,10 +1235,14 @@ uint64_t HermesRuntime::getUniqueID(const jsi::Object &o) const {
   return impl(this)->runtime_.getHeap().getObjectID(
       static_cast<vm::GCCell *>(impl(this)->phv(o).getObject()));
 }
+
+#if JSI_VERSION >= 8
 uint64_t HermesRuntime::getUniqueID(const jsi::BigInt &s) const {
   return impl(this)->runtime_.getHeap().getObjectID(
       static_cast<vm::GCCell *>(impl(this)->phv(s).getBigInt()));
 }
+#endif
+
 uint64_t HermesRuntime::getUniqueID(const jsi::String &s) const {
   return impl(this)->runtime_.getHeap().getObjectID(
       static_cast<vm::GCCell *>(impl(this)->phv(s).getString()));
@@ -1507,6 +1538,7 @@ jsi::Value HermesRuntimeImpl::evaluateJavaScript(
   return evaluateJavaScriptWithSourceMap(buffer, nullptr, sourceURL);
 }
 
+#if JSI_VERSION >= 4
 bool HermesRuntimeImpl::drainMicrotasks(int maxMicrotasksHint) {
   if (runtime_.hasMicrotaskQueue()) {
     checkStatus(runtime_.drainJobs());
@@ -1516,6 +1548,7 @@ bool HermesRuntimeImpl::drainMicrotasks(int maxMicrotasksHint) {
   runtime_.clearKeptObjects();
   return true;
 }
+#endif
 
 jsi::Object HermesRuntimeImpl::global() {
   return add<jsi::Object>(runtime_.getGlobal().getHermesValue());
@@ -1547,10 +1580,12 @@ jsi::Runtime::PointerValue *HermesRuntimeImpl::cloneSymbol(
   return clone(pv);
 }
 
+#if JSI_VERSION >= 6
 jsi::Runtime::PointerValue *HermesRuntimeImpl::cloneBigInt(
     const Runtime::PointerValue *pv) {
   return clone(pv);
 }
+#endif
 
 jsi::Runtime::PointerValue *HermesRuntimeImpl::cloneString(
     const Runtime::PointerValue *pv) {
@@ -1607,10 +1642,12 @@ jsi::PropNameID HermesRuntimeImpl::createPropNameIDFromString(
   return add<jsi::PropNameID>(cr->getHermesValue());
 }
 
+#if JSI_VERSION >= 5
 jsi::PropNameID HermesRuntimeImpl::createPropNameIDFromSymbol(
     const jsi::Symbol &sym) {
   return add<jsi::PropNameID>(phv(sym));
 }
+#endif
 
 std::string HermesRuntimeImpl::utf8(const jsi::PropNameID &sym) {
   vm::GCScope gcScope(runtime_);
@@ -1654,6 +1691,7 @@ std::string HermesRuntimeImpl::symbolToString(const jsi::Symbol &sym) {
   return toStdString(runtime_, res.getValue());
 }
 
+#if JSI_VERSION >= 8
 jsi::BigInt HermesRuntimeImpl::createBigIntFromInt64(int64_t value) {
   vm::GCScope gcScope(runtime_);
   vm::CallResult<vm::HermesValue> res =
@@ -1703,6 +1741,7 @@ jsi::String HermesRuntimeImpl::bigintToString(
   checkStatus(toStringRes.getStatus());
   return add<jsi::String>(*toStringRes);
 }
+#endif
 
 jsi::String HermesRuntimeImpl::createStringFromAscii(
     const char *str,
@@ -1732,6 +1771,7 @@ std::string HermesRuntimeImpl::utf8(const jsi::String &str) {
   return toStdString(runtime_, handle);
 }
 
+#if JSI_VERSION >= 2
 jsi::Value HermesRuntimeImpl::createValueFromJsonUtf8(
     const uint8_t *json,
     size_t length) {
@@ -1742,6 +1782,7 @@ jsi::Value HermesRuntimeImpl::createValueFromJsonUtf8(
   checkStatus(res.getStatus());
   return valueFromHermesValue(*res);
 }
+#endif
 
 jsi::Object HermesRuntimeImpl::createObject() {
   vm::GCScope gcScope(runtime_);
@@ -1765,6 +1806,7 @@ std::shared_ptr<jsi::HostObject> HermesRuntimeImpl::getHostObject(
   return static_cast<const JsiProxy *>(proxy)->ho_;
 }
 
+#if JSI_VERSION >= 7
 bool HermesRuntimeImpl::hasNativeState(const jsi::Object &obj) {
   vm::GCScope gcScope(runtime_);
   auto h = handle(obj);
@@ -1835,6 +1877,7 @@ std::shared_ptr<jsi::NativeState> HermesRuntimeImpl::getNativeState(
   return std::shared_ptr(
       *reinterpret_cast<std::shared_ptr<jsi::NativeState> *>(ns->context()));
 }
+#endif
 
 jsi::Value HermesRuntimeImpl::getProperty(
     const jsi::Object &obj,
@@ -1879,7 +1922,7 @@ bool HermesRuntimeImpl::hasProperty(
 }
 
 void HermesRuntimeImpl::setPropertyValue(
-    const jsi::Object &obj,
+    JSI_CONST_10 jsi::Object &obj,
     const jsi::String &name,
     const jsi::Value &value) {
   vm::GCScope gcScope(runtime_);
@@ -1894,7 +1937,7 @@ void HermesRuntimeImpl::setPropertyValue(
 }
 
 void HermesRuntimeImpl::setPropertyValue(
-    const jsi::Object &obj,
+    JSI_CONST_10 jsi::Object &obj,
     const jsi::PropNameID &name,
     const jsi::Value &value) {
   vm::GCScope gcScope(runtime_);
@@ -1963,7 +2006,8 @@ jsi::WeakObject HermesRuntimeImpl::createWeakObject(const jsi::Object &obj) {
       static_cast<vm::JSObject *>(phv(obj).getObject()), runtime_));
 }
 
-jsi::Value HermesRuntimeImpl::lockWeakObject(const jsi::WeakObject &wo) {
+jsi::Value HermesRuntimeImpl::lockWeakObject(
+    JSI_NO_CONST_3 JSI_CONST_10 jsi::WeakObject &wo) {
   const vm::WeakRoot<vm::JSObject> &wr = weakRoot(wo);
 
   if (const auto ptr = wr.get(runtime_, runtime_.getHeap()))
@@ -1979,6 +2023,7 @@ jsi::Array HermesRuntimeImpl::createArray(size_t length) {
   return add<jsi::Object>(result->getHermesValue()).getArray(*this);
 }
 
+#if JSI_VERSION >= 9
 jsi::ArrayBuffer HermesRuntimeImpl::createArrayBuffer(
     std::shared_ptr<jsi::MutableBuffer> buffer) {
   vm::GCScope gcScope(runtime_);
@@ -1996,6 +2041,7 @@ jsi::ArrayBuffer HermesRuntimeImpl::createArrayBuffer(
   checkStatus(res);
   return add<jsi::Object>(buf.getHermesValue()).getArrayBuffer(*this);
 }
+#endif
 
 size_t HermesRuntimeImpl::size(const jsi::Array &arr) {
   vm::GCScope gcScope(runtime_);
@@ -2033,7 +2079,7 @@ jsi::Value HermesRuntimeImpl::getValueAtIndex(const jsi::Array &arr, size_t i) {
 }
 
 void HermesRuntimeImpl::setValueAtIndexImpl(
-    const jsi::Array &arr,
+    JSI_CONST_10 jsi::Array &arr,
     size_t i,
     const jsi::Value &value) {
   vm::GCScope gcScope(runtime_);
@@ -2197,10 +2243,12 @@ bool HermesRuntimeImpl::strictEquals(const jsi::Symbol &a, const jsi::Symbol &b)
   return phv(a).getSymbol() == phv(b).getSymbol();
 }
 
+#if JSI_VERSION >= 6
 bool HermesRuntimeImpl::strictEquals(const jsi::BigInt &a, const jsi::BigInt &b)
     const {
   return phv(a).getBigInt()->compare(phv(b).getBigInt()) == 0;
 }
+#endif
 
 bool HermesRuntimeImpl::strictEquals(const jsi::String &a, const jsi::String &b)
     const {

--- a/API/hermes/hermes.h
+++ b/API/hermes/hermes.h
@@ -121,7 +121,9 @@ class HERMES_EXPORT HermesRuntime : public jsi::Runtime {
   /// static throughout that object's (or string's, or PropNameID's)
   /// lifetime.
   uint64_t getUniqueID(const jsi::Object &o) const;
+#if JSI_VERSION >= 8
   uint64_t getUniqueID(const jsi::BigInt &s) const;
+#endif
   uint64_t getUniqueID(const jsi::String &s) const;
   uint64_t getUniqueID(const jsi::PropNameID &pni) const;
   uint64_t getUniqueID(const jsi::Symbol &sym) const;

--- a/API/jsi/jsi/.clang-format
+++ b/API/jsi/jsi/.clang-format
@@ -1,0 +1,4 @@
+---
+BasedOnStyle: InheritParentConfig
+PointerAlignment: Left
+...

--- a/API/jsi/jsi/JSIDynamic.cpp
+++ b/API/jsi/jsi/JSIDynamic.cpp
@@ -139,8 +139,10 @@ void dynamicFromValueShallow(
       output = folly::dynamic::object();
     }
     stack.emplace_back(&output, std::move(obj));
+#if JSI_VERSION >= 8
   } else if (value.isBigInt()) {
     throw JSError(runtime, "JS BigInts are not convertible to dynamic");
+#endif
   } else if (value.isSymbol()) {
     throw JSError(runtime, "JS Symbols are not convertible to dynamic");
   } else {

--- a/API/jsi/jsi/README.md
+++ b/API/jsi/jsi/README.md
@@ -1,0 +1,25 @@
+# JavaScript Interface 
+
+This folder contains definitions for JSI.
+JSI is the public API for Hermes engine.
+It is being used by React Native project to work with JS engines.
+
+## JSI versions
+
+JSI has versions associated with the following commit hashes in the 
+https://github.com/facebook/hermes repo. 
+
+| Version | Commit Hash                              | Commit Description
+|--------:|:-----------------------------------------|------------------------------------------------------
+|      10 | `b81666598672cb5f8b365fe6548d3273f216322e` | Clarify const-ness of JSI references
+|       9 | `e6d887ae96bef5c71032f11ed1a9fb9fecec7b46` | Add external ArrayBuffers to JSI
+|       8 | `4d64e61a1f9926eca0afd4eb38d17cea30bdc34c` | Add BigInt JSI API support
+|         | `e8cc57311877464478da5421265bcc898098e136` | Add methods for creating and interacting with BigInt
+|       7 | `4efad65b8266e3f26e04e3ca9addf92fc4d6ded8` | Add API for setting/getting native state
+|       6 | `bc3cfb87fbfc82732936ec4445c9765bf9a5f08a` | Add BigInt skeleton
+|       5 | `2b6d408980d7f23f50602fd88169c8a9881592a6` | Add PropNameID::fromSymbol
+|       4 | `a5bee55c8301bb8662e408feee28bbc3e2a1fc81` | Introduce drainMicrotasks to JSI
+|       3 | `0c9daa5a5eee7649558a53e3e541b80c89048c42` | Change jsi::Runtime::lockWeakObject to take a mutable ref
+|       2 | `e0616e77e1ddc3ea5e2ccbca2e20dd0c4049c637` | Make it possible for a Runtime implementation to provide its own JSON parsing
+|       1 | `3ba9615f80913764ecb6456779d502e31dde9e5d` | Fix build break in MSVC (#26462)
+|       0 | `f22a18f67da3f03db59c1ec715d6ec3776b03fbf` | Initial commit

--- a/API/jsi/jsi/decorator.h
+++ b/API/jsi/jsi/decorator.h
@@ -126,9 +126,11 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
       const std::shared_ptr<const PreparedJavaScript>& js) override {
     return plain().evaluatePreparedJavaScript(js);
   }
+#if JSI_VERSION >= 4
   bool drainMicrotasks(int maxMicrotasksHint) override {
     return plain().drainMicrotasks(maxMicrotasksHint);
   }
+#endif
   Object global() override {
     return plain().global();
   }
@@ -154,9 +156,11 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   Runtime::PointerValue* cloneSymbol(const Runtime::PointerValue* pv) override {
     return plain_.cloneSymbol(pv);
   };
+#if JSI_VERSION >= 6
   Runtime::PointerValue* cloneBigInt(const Runtime::PointerValue* pv) override {
     return plain_.cloneBigInt(pv);
   };
+#endif
   Runtime::PointerValue* cloneString(const Runtime::PointerValue* pv) override {
     return plain_.cloneString(pv);
   };
@@ -179,9 +183,11 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   PropNameID createPropNameIDFromString(const String& str) override {
     return plain_.createPropNameIDFromString(str);
   };
+#if JSI_VERSION >= 5
   PropNameID createPropNameIDFromSymbol(const Symbol& sym) override {
     return plain_.createPropNameIDFromSymbol(sym);
   };
+#endif
   std::string utf8(const PropNameID& id) override {
     return plain_.utf8(id);
   };
@@ -193,6 +199,7 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
     return plain_.symbolToString(sym);
   }
 
+#if JSI_VERSION >= 8
   BigInt createBigIntFromInt64(int64_t value) override {
     return plain_.createBigIntFromInt64(value);
   }
@@ -211,6 +218,7 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   String bigintToString(const BigInt& bigint, int radix) override {
     return plain_.bigintToString(bigint, radix);
   }
+#endif
 
   String createStringFromAscii(const char* str, size_t length) override {
     return plain_.createStringFromAscii(str, length);
@@ -241,6 +249,7 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
     return dhf.target<DecoratedHostFunction>()->plainHF_;
   };
 
+#if JSI_VERSION >= 7
   bool hasNativeState(const Object& o) override {
     return plain_.hasNativeState(o);
   }
@@ -251,6 +260,7 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
       override {
     plain_.setNativeState(o, state);
   }
+#endif
 
   Value getProperty(const Object& o, const PropNameID& name) override {
     return plain_.getProperty(o, name);
@@ -265,13 +275,15 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
     return plain_.hasProperty(o, name);
   };
   void setPropertyValue(
-      const Object& o,
+      JSI_CONST_10 Object& o,
       const PropNameID& name,
       const Value& value) override {
     plain_.setPropertyValue(o, name, value);
   };
-  void setPropertyValue(const Object& o, const String& name, const Value& value)
-      override {
+  void setPropertyValue(
+      JSI_CONST_10 Object& o,
+      const String& name,
+      const Value& value) override {
     plain_.setPropertyValue(o, name, value);
   };
 
@@ -297,17 +309,19 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   WeakObject createWeakObject(const Object& o) override {
     return plain_.createWeakObject(o);
   };
-  Value lockWeakObject(const WeakObject& wo) override {
+  Value lockWeakObject(JSI_NO_CONST_3 JSI_CONST_10 WeakObject& wo) override {
     return plain_.lockWeakObject(wo);
   };
 
   Array createArray(size_t length) override {
     return plain_.createArray(length);
   };
+#if JSI_VERSION >= 9
   ArrayBuffer createArrayBuffer(
       std::shared_ptr<MutableBuffer> buffer) override {
     return plain_.createArrayBuffer(std::move(buffer));
   };
+#endif
   size_t size(const Array& a) override {
     return plain_.size(a);
   };
@@ -320,7 +334,7 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   Value getValueAtIndex(const Array& a, size_t i) override {
     return plain_.getValueAtIndex(a, i);
   };
-  void setValueAtIndexImpl(const Array& a, size_t i, const Value& value)
+  void setValueAtIndexImpl(JSI_CONST_10 Array& a, size_t i, const Value& value)
       override {
     plain_.setValueAtIndexImpl(a, i, value);
   };
@@ -355,9 +369,11 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   bool strictEquals(const Symbol& a, const Symbol& b) const override {
     return plain_.strictEquals(a, b);
   };
+#if JSI_VERSION >= 6
   bool strictEquals(const BigInt& a, const BigInt& b) const override {
     return plain_.strictEquals(a, b);
   };
+#endif
   bool strictEquals(const String& a, const String& b) const override {
     return plain_.strictEquals(a, b);
   };
@@ -540,10 +556,12 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     return RD::evaluatePreparedJavaScript(js);
   }
+#if JSI_VERSION >= 4
   bool drainMicrotasks(int maxMicrotasksHint) override {
     Around around{with_};
     return RD::drainMicrotasks(maxMicrotasksHint);
   }
+#endif
   Object global() override {
     Around around{with_};
     return RD::global();
@@ -660,14 +678,16 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     return RD::hasProperty(o, name);
   };
   void setPropertyValue(
-      const Object& o,
+      JSI_CONST_10 Object& o,
       const PropNameID& name,
       const Value& value) override {
     Around around{with_};
     RD::setPropertyValue(o, name, value);
   };
-  void setPropertyValue(const Object& o, const String& name, const Value& value)
-      override {
+  void setPropertyValue(
+      JSI_CONST_10 Object& o,
+      const String& name,
+      const Value& value) override {
     Around around{with_};
     RD::setPropertyValue(o, name, value);
   };
@@ -701,7 +721,7 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     return RD::createWeakObject(o);
   };
-  Value lockWeakObject(const WeakObject& wo) override {
+  Value lockWeakObject(JSI_NO_CONST_3 JSI_CONST_10 WeakObject& wo) override {
     Around around{with_};
     return RD::lockWeakObject(wo);
   };
@@ -710,10 +730,12 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     return RD::createArray(length);
   };
+#if JSI_VERSION >= 9
   ArrayBuffer createArrayBuffer(
       std::shared_ptr<MutableBuffer> buffer) override {
     return RD::createArrayBuffer(std::move(buffer));
   };
+#endif
   size_t size(const Array& a) override {
     Around around{with_};
     return RD::size(a);
@@ -730,7 +752,7 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     return RD::getValueAtIndex(a, i);
   };
-  void setValueAtIndexImpl(const Array& a, size_t i, const Value& value)
+  void setValueAtIndexImpl(JSI_CONST_10 Array& a, size_t i, const Value& value)
       override {
     Around around{with_};
     RD::setValueAtIndexImpl(a, i, value);

--- a/API/jsi/jsi/jsi-inl.h
+++ b/API/jsi/jsi/jsi-inl.h
@@ -70,9 +70,11 @@ inline T Runtime::make(Runtime::PointerValue* pv) {
   return T(pv);
 }
 
+#if JSI_VERSION >= 3
 inline Runtime::PointerValue* Runtime::getPointerValue(jsi::Pointer& pointer) {
   return pointer.ptr_;
 }
+#endif
 
 inline const Runtime::PointerValue* Runtime::getPointerValue(
     const jsi::Pointer& pointer) {
@@ -111,21 +113,22 @@ inline bool Object::hasProperty(Runtime& runtime, const PropNameID& name)
 }
 
 template <typename T>
-void Object::setProperty(Runtime& runtime, const char* name, T&& value) const {
+void Object::setProperty(Runtime& runtime, const char* name, T&& value)
+    JSI_CONST_10 {
   setProperty(
       runtime, String::createFromAscii(runtime, name), std::forward<T>(value));
 }
 
 template <typename T>
 void Object::setProperty(Runtime& runtime, const String& name, T&& value)
-    const {
+    JSI_CONST_10 {
   setPropertyValue(
       runtime, name, detail::toValue(runtime, std::forward<T>(value)));
 }
 
 template <typename T>
 void Object::setProperty(Runtime& runtime, const PropNameID& name, T&& value)
-    const {
+    JSI_CONST_10 {
   setPropertyValue(
       runtime, name, detail::toValue(runtime, std::forward<T>(value)));
 }
@@ -204,6 +207,7 @@ inline std::shared_ptr<HostObject> Object::getHostObject<HostObject>(
   return runtime.getHostObject(*this);
 }
 
+#if JSI_VERSION >= 7
 template <typename T>
 inline bool Object::hasNativeState(Runtime& runtime) const {
   return runtime.hasNativeState(*this) &&
@@ -226,17 +230,19 @@ inline void Object::setNativeState(
     std::shared_ptr<NativeState> state) const {
   runtime.setNativeState(*this, state);
 }
+#endif
 
 inline Array Object::getPropertyNames(Runtime& runtime) const {
   return runtime.getPropertyNames(*this);
 }
 
-inline Value WeakObject::lock(Runtime& runtime) const {
+inline Value WeakObject::lock(Runtime& runtime) JSI_CONST_10 {
   return runtime.lockWeakObject(*this);
 }
 
 template <typename T>
-void Array::setValueAtIndex(Runtime& runtime, size_t i, T&& value) const {
+void Array::setValueAtIndex(Runtime& runtime, size_t i, T&& value)
+    JSI_CONST_10 {
   setValueAtIndexImpl(
       runtime, i, detail::toValue(runtime, std::forward<T>(value)));
 }
@@ -314,7 +320,7 @@ inline std::vector<PropNameID> PropNameID::names(
 
 template <size_t N>
 inline std::vector<PropNameID> PropNameID::names(
-    PropNameID(&&propertyNames)[N]) {
+    PropNameID (&&propertyNames)[N]) {
   std::vector<PropNameID> result;
   result.reserve(N);
   for (auto& name : propertyNames) {
@@ -343,9 +349,11 @@ inline Value Function::callAsConstructor(Runtime& runtime, Args&&... args)
       runtime, {detail::toValue(runtime, std::forward<Args>(args))...});
 }
 
+#if JSI_VERSION >= 8
 String BigInt::toString(Runtime& runtime, int radix) const {
   return runtime.bigintToString(*this, radix);
 }
+#endif
 
 } // namespace jsi
 } // namespace facebook

--- a/API/jsi/jsi/jsi.cpp
+++ b/API/jsi/jsi/jsi.cpp
@@ -32,8 +32,10 @@ std::string kindToString(const Value& v, Runtime* rt = nullptr) {
     return "a string";
   } else if (v.isSymbol()) {
     return "a symbol";
+#if JSI_VERSION >= 6
   } else if (v.isBigInt()) {
     return "a bigint";
+#endif
   } else {
     assert(v.isObject() && "Expecting object.");
     return rt != nullptr && v.getObject(*rt).isFunction(*rt) ? "a function"
@@ -66,7 +68,9 @@ Value callGlobalFunction(Runtime& runtime, const char* name, const Value& arg) {
 
 Buffer::~Buffer() = default;
 
+#if JSI_VERSION >= 9
 MutableBuffer::~MutableBuffer() = default;
+#endif
 
 PreparedJavaScript::~PreparedJavaScript() = default;
 
@@ -83,7 +87,9 @@ void HostObject::set(Runtime& rt, const PropNameID& name, const Value&) {
 
 HostObject::~HostObject() {}
 
+#if JSI_VERSION >= 7
 NativeState::~NativeState() {}
+#endif
 
 Runtime::~Runtime() {}
 
@@ -136,12 +142,24 @@ Instrumentation& Runtime::instrumentation() {
   return sharedInstance;
 }
 
+#if JSI_VERSION >= 2
 Value Runtime::createValueFromJsonUtf8(const uint8_t* json, size_t length) {
   Function parseJson = global()
                            .getPropertyAsObject(*this, "JSON")
                            .getPropertyAsFunction(*this, "parse");
   return parseJson.call(*this, String::createFromUtf8(*this, json, length));
 }
+#else
+Value Value::createFromJsonUtf8(
+    Runtime& runtime,
+    const uint8_t* json,
+    size_t length) {
+  Function parseJson = runtime.global()
+                           .getPropertyAsObject(runtime, "JSON")
+                           .getPropertyAsFunction(runtime, "parse");
+  return parseJson.call(runtime, String::createFromUtf8(runtime, json, length));
+}
+#endif
 
 Pointer& Pointer::operator=(Pointer&& other) {
   if (ptr_) {
@@ -240,8 +258,10 @@ Value::Value(Runtime& runtime, const Value& other) : Value(other.kind_) {
     data_.number = other.data_.number;
   } else if (kind_ == SymbolKind) {
     new (&data_.pointer) Pointer(runtime.cloneSymbol(other.data_.pointer.ptr_));
+#if JSI_VERSION >= 6
   } else if (kind_ == BigIntKind) {
     new (&data_.pointer) Pointer(runtime.cloneBigInt(other.data_.pointer.ptr_));
+#endif
   } else if (kind_ == StringKind) {
     new (&data_.pointer) Pointer(runtime.cloneString(other.data_.pointer.ptr_));
   } else if (kind_ >= ObjectKind) {
@@ -271,10 +291,12 @@ bool Value::strictEquals(Runtime& runtime, const Value& a, const Value& b) {
       return runtime.strictEquals(
           static_cast<const Symbol&>(a.data_.pointer),
           static_cast<const Symbol&>(b.data_.pointer));
+#if JSI_VERSION >= 6
     case BigIntKind:
       return runtime.strictEquals(
           static_cast<const BigInt&>(a.data_.pointer),
           static_cast<const BigInt&>(b.data_.pointer));
+#endif
     case StringKind:
       return runtime.strictEquals(
           static_cast<const String&>(a.data_.pointer),
@@ -342,6 +364,7 @@ Symbol Value::asSymbol(Runtime& rt) && {
   return std::move(*this).getSymbol(rt);
 }
 
+#if JSI_VERSION >= 6
 BigInt Value::asBigInt(Runtime& rt) const& {
   if (!isBigInt()) {
     throw JSError(
@@ -359,6 +382,7 @@ BigInt Value::asBigInt(Runtime& rt) && {
 
   return std::move(*this).getBigInt(rt);
 }
+#endif
 
 String Value::asString(Runtime& rt) const& {
   if (!isString()) {
@@ -383,6 +407,7 @@ String Value::toString(Runtime& runtime) const {
   return toString.call(runtime, *this).getString(runtime);
 }
 
+#if JSI_VERSION >= 8
 uint64_t BigInt::asUint64(Runtime& runtime) const {
   if (!isUint64(runtime)) {
     throw JSError(runtime, "Lossy truncation in BigInt64::asUint64");
@@ -396,6 +421,7 @@ int64_t BigInt::asInt64(Runtime& runtime) const {
   }
   return getInt64(runtime);
 }
+#endif
 
 Array Array::createWithElements(
     Runtime& rt,

--- a/API/jsi/jsi/jsi.h
+++ b/API/jsi/jsi/jsi.h
@@ -27,6 +27,24 @@
 #endif // _MSC_VER
 #endif // !defined(JSI_EXPORT)
 
+// JSI version defines set of features available in the API.
+// Each significant API change must be under a new version.
+#ifndef JSI_VERSION
+#define JSI_VERSION 10
+#endif
+
+#if JSI_VERSION >= 3
+#define JSI_NO_CONST_3
+#else
+#define JSI_NO_CONST_3 const
+#endif
+
+#if JSI_VERSION >= 10
+#define JSI_CONST_10 const
+#else
+#define JSI_CONST_10
+#endif
+
 class FBJSRuntime;
 namespace facebook {
 namespace jsi {
@@ -56,6 +74,7 @@ class JSI_EXPORT StringBuffer : public Buffer {
   std::string s_;
 };
 
+#if JSI_VERSION >= 9
 /// Base class for buffers of data that need to be passed to the runtime. The
 /// result of size() and data() must not change after construction. However, the
 /// region pointed to by data() may be modified by the user or the runtime. The
@@ -67,6 +86,7 @@ class JSI_EXPORT MutableBuffer {
   virtual size_t size() const = 0;
   virtual uint8_t* data() = 0;
 };
+#endif
 
 /// PreparedJavaScript is a base class representing JavaScript which is in a
 /// form optimized for execution, in a runtime-specific way. Construct one via
@@ -84,7 +104,9 @@ class Runtime;
 class Pointer;
 class PropNameID;
 class Symbol;
+#if JSI_VERSION >= 6
 class BigInt;
+#endif
 class String;
 class Object;
 class WeakObject;
@@ -144,12 +166,14 @@ class JSI_EXPORT HostObject {
   virtual std::vector<PropNameID> getPropertyNames(Runtime& rt);
 };
 
+#if JSI_VERSION >= 7
 /// Native state (and destructor) that can be attached to any JS object
 /// using setNativeState.
 class JSI_EXPORT NativeState {
  public:
   virtual ~NativeState();
 };
+#endif
 
 /// Represents a JS runtime.  Movable, but not copyable.  Note that
 /// this object may not be thread-aware, but cannot be used safely from
@@ -209,6 +233,7 @@ class JSI_EXPORT Runtime {
   virtual Value evaluatePreparedJavaScript(
       const std::shared_ptr<const PreparedJavaScript>& js) = 0;
 
+#if JSI_VERSION >= 4
   /// Drain the JavaScript VM internal Microtask (a.k.a. Job in ECMA262) queue.
   ///
   /// \param maxMicrotasksHint a hint to tell an implementation that it should
@@ -237,6 +262,7 @@ class JSI_EXPORT Runtime {
   /// the time this is written, An implementation may swallow exceptions (JSC),
   /// may not pause (V8), and may not support bounded executions.
   virtual bool drainMicrotasks(int maxMicrotasksHint = -1) = 0;
+#endif
 
   /// \return the global object
   virtual Object global() = 0;
@@ -264,7 +290,9 @@ class JSI_EXPORT Runtime {
   friend class Pointer;
   friend class PropNameID;
   friend class Symbol;
+#if JSI_VERSION >= 6
   friend class BigInt;
+#endif
   friend class String;
   friend class Object;
   friend class WeakObject;
@@ -288,7 +316,9 @@ class JSI_EXPORT Runtime {
   };
 
   virtual PointerValue* cloneSymbol(const Runtime::PointerValue* pv) = 0;
+#if JSI_VERSION >= 6
   virtual PointerValue* cloneBigInt(const Runtime::PointerValue* pv) = 0;
+#endif
   virtual PointerValue* cloneString(const Runtime::PointerValue* pv) = 0;
   virtual PointerValue* cloneObject(const Runtime::PointerValue* pv) = 0;
   virtual PointerValue* clonePropNameID(const Runtime::PointerValue* pv) = 0;
@@ -300,18 +330,22 @@ class JSI_EXPORT Runtime {
       const uint8_t* utf8,
       size_t length) = 0;
   virtual PropNameID createPropNameIDFromString(const String& str) = 0;
+#if JSI_VERSION >= 5
   virtual PropNameID createPropNameIDFromSymbol(const Symbol& sym) = 0;
+#endif
   virtual std::string utf8(const PropNameID&) = 0;
   virtual bool compare(const PropNameID&, const PropNameID&) = 0;
 
   virtual std::string symbolToString(const Symbol&) = 0;
 
+#if JSI_VERSION >= 8
   virtual BigInt createBigIntFromInt64(int64_t) = 0;
   virtual BigInt createBigIntFromUint64(uint64_t) = 0;
   virtual bool bigintIsInt64(const BigInt&) = 0;
   virtual bool bigintIsUint64(const BigInt&) = 0;
   virtual uint64_t truncate(const BigInt&) = 0;
   virtual String bigintToString(const BigInt&, int) = 0;
+#endif
 
   virtual String createStringFromAscii(const char* str, size_t length) = 0;
   virtual String createStringFromUtf8(const uint8_t* utf8, size_t length) = 0;
@@ -319,29 +353,35 @@ class JSI_EXPORT Runtime {
 
   // \return a \c Value created from a utf8-encoded JSON string. The default
   // implementation creates a \c String and invokes JSON.parse.
+#if JSI_VERSION >= 2
   virtual Value createValueFromJsonUtf8(const uint8_t* json, size_t length);
+#endif
 
   virtual Object createObject() = 0;
   virtual Object createObject(std::shared_ptr<HostObject> ho) = 0;
   virtual std::shared_ptr<HostObject> getHostObject(const jsi::Object&) = 0;
   virtual HostFunctionType& getHostFunction(const jsi::Function&) = 0;
 
+#if JSI_VERSION >= 7
   virtual bool hasNativeState(const jsi::Object&) = 0;
   virtual std::shared_ptr<NativeState> getNativeState(const jsi::Object&) = 0;
   virtual void setNativeState(
       const jsi::Object&,
       std::shared_ptr<NativeState> state) = 0;
+#endif
 
   virtual Value getProperty(const Object&, const PropNameID& name) = 0;
   virtual Value getProperty(const Object&, const String& name) = 0;
   virtual bool hasProperty(const Object&, const PropNameID& name) = 0;
   virtual bool hasProperty(const Object&, const String& name) = 0;
   virtual void setPropertyValue(
-      const Object&,
+      JSI_CONST_10 Object&,
       const PropNameID& name,
       const Value& value) = 0;
-  virtual void
-  setPropertyValue(const Object&, const String& name, const Value& value) = 0;
+  virtual void setPropertyValue(
+      JSI_CONST_10 Object&,
+      const String& name,
+      const Value& value) = 0;
 
   virtual bool isArray(const Object&) const = 0;
   virtual bool isArrayBuffer(const Object&) const = 0;
@@ -351,17 +391,19 @@ class JSI_EXPORT Runtime {
   virtual Array getPropertyNames(const Object&) = 0;
 
   virtual WeakObject createWeakObject(const Object&) = 0;
-  virtual Value lockWeakObject(const WeakObject&) = 0;
+  virtual Value lockWeakObject(JSI_NO_CONST_3 JSI_CONST_10 WeakObject&) = 0;
 
   virtual Array createArray(size_t length) = 0;
+#if JSI_VERSION >= 9
   virtual ArrayBuffer createArrayBuffer(
       std::shared_ptr<MutableBuffer> buffer) = 0;
+#endif
   virtual size_t size(const Array&) = 0;
   virtual size_t size(const ArrayBuffer&) = 0;
   virtual uint8_t* data(const ArrayBuffer&) = 0;
   virtual Value getValueAtIndex(const Array&, size_t i) = 0;
   virtual void
-  setValueAtIndexImpl(const Array&, size_t i, const Value& value) = 0;
+  setValueAtIndexImpl(JSI_CONST_10 Array&, size_t i, const Value& value) = 0;
 
   virtual Function createFunctionFromHostFunction(
       const PropNameID& name,
@@ -381,7 +423,9 @@ class JSI_EXPORT Runtime {
   virtual void popScope(ScopeState*);
 
   virtual bool strictEquals(const Symbol& a, const Symbol& b) const = 0;
+#if JSI_VERSION >= 6
   virtual bool strictEquals(const BigInt& a, const BigInt& b) const = 0;
+#endif
   virtual bool strictEquals(const String& a, const String& b) const = 0;
   virtual bool strictEquals(const Object& a, const Object& b) const = 0;
 
@@ -391,7 +435,9 @@ class JSI_EXPORT Runtime {
   // Value, Symbol, String, and Object, which are all friends of Runtime.
   template <typename T>
   static T make(PointerValue* pv);
+#if JSI_VERSION >= 3
   static PointerValue* getPointerValue(Pointer& pointer);
+#endif
   static const PointerValue* getPointerValue(const Pointer& pointer);
   static const PointerValue* getPointerValue(const Value& value);
 
@@ -471,10 +517,12 @@ class JSI_EXPORT PropNameID : public Pointer {
     return runtime.createPropNameIDFromString(str);
   }
 
+#if JSI_VERSION >= 5
   /// Create a PropNameID from a JS symbol.
   static PropNameID forSymbol(Runtime& runtime, const jsi::Symbol& sym) {
     return runtime.createPropNameIDFromSymbol(sym);
   }
+#endif
 
   // Creates a vector of PropNameIDs constructed from given arguments.
   template <typename... Args>
@@ -482,7 +530,7 @@ class JSI_EXPORT PropNameID : public Pointer {
 
   // Creates a vector of given PropNameIDs.
   template <size_t N>
-  static std::vector<PropNameID> names(PropNameID(&&propertyNames)[N]);
+  static std::vector<PropNameID> names(PropNameID (&&propertyNames)[N]);
 
   /// Copies the data in a PropNameID as utf8 into a C++ string.
   std::string utf8(Runtime& runtime) const {
@@ -527,6 +575,7 @@ class JSI_EXPORT Symbol : public Pointer {
   friend class Value;
 };
 
+#if JSI_VERSION >= 6
 /// Represents a JS BigInt.  Movable, not copyable.
 class JSI_EXPORT BigInt : public Pointer {
  public:
@@ -535,6 +584,7 @@ class JSI_EXPORT BigInt : public Pointer {
   BigInt(BigInt&& other) = default;
   BigInt& operator=(BigInt&& other) = default;
 
+#if JSI_VERSION >= 8
   /// Create a BigInt representing the signed 64-bit \p value.
   static BigInt fromInt64(Runtime& runtime, int64_t value) {
     return runtime.createBigIntFromInt64(value);
@@ -581,10 +631,12 @@ class JSI_EXPORT BigInt : public Pointer {
   /// \returns this BigInt converted to a String in base \p radix. Throws a
   /// JSIException if radix is not in the [2, 36] range.
   inline String toString(Runtime& runtime, int radix = 10) const;
+#endif
 
   friend class Runtime;
   friend class Value;
 };
+#endif
 
 /// Represents a JS String.  Movable, not copyable.
 class JSI_EXPORT String : public Pointer {
@@ -669,7 +721,7 @@ class JSI_EXPORT Object : public Pointer {
   }
 
   /// \return the result of `this instanceOf ctor` in JS.
-  bool instanceOf(Runtime& rt, const Function& ctor) const {
+  bool instanceOf(Runtime& rt, const Function& ctor) JSI_CONST_10 {
     return rt.instanceOf(*this, ctor);
   }
 
@@ -704,19 +756,21 @@ class JSI_EXPORT Object : public Pointer {
   /// used to make one: nullptr_t, bool, double, int, const char*,
   /// String, or Object.
   template <typename T>
-  void setProperty(Runtime& runtime, const char* name, T&& value) const;
+  void setProperty(Runtime& runtime, const char* name, T&& value) JSI_CONST_10;
 
   /// Sets the property value from a Value or anything which can be
   /// used to make one: nullptr_t, bool, double, int, const char*,
   /// String, or Object.
   template <typename T>
-  void setProperty(Runtime& runtime, const String& name, T&& value) const;
+  void setProperty(Runtime& runtime, const String& name, T&& value)
+      JSI_CONST_10;
 
   /// Sets the property value from a Value or anything which can be
   /// used to make one: nullptr_t, bool, double, int, const char*,
   /// String, or Object.
   template <typename T>
-  void setProperty(Runtime& runtime, const PropNameID& name, T&& value) const;
+  void setProperty(Runtime& runtime, const PropNameID& name, T&& value)
+      JSI_CONST_10;
 
   /// \return true iff JS \c Array.isArray() would return \c true.  If
   /// so, then \c getArray() will succeed.
@@ -799,6 +853,7 @@ class JSI_EXPORT Object : public Pointer {
   template <typename T = HostObject>
   std::shared_ptr<T> asHostObject(Runtime& runtime) const;
 
+#if JSI_VERSION >= 7
   /// \return whether this object has native state of type T previously set by
   /// \c setNativeState.
   template <typename T = NativeState>
@@ -817,6 +872,7 @@ class JSI_EXPORT Object : public Pointer {
   /// Throws a type error if this object is a proxy or host object.
   void setNativeState(Runtime& runtime, std::shared_ptr<NativeState> state)
       const;
+#endif
 
   /// \return same as \c getProperty(name).asObject(), except with
   /// a better exception message.
@@ -838,14 +894,14 @@ class JSI_EXPORT Object : public Pointer {
   void setPropertyValue(
       Runtime& runtime,
       const String& name,
-      const Value& value) const {
+      const Value& value) JSI_CONST_10 {
     return runtime.setPropertyValue(*this, name, value);
   }
 
   void setPropertyValue(
       Runtime& runtime,
       const PropNameID& name,
-      const Value& value) const {
+      const Value& value) JSI_CONST_10 {
     return runtime.setPropertyValue(*this, name, value);
   }
 
@@ -871,7 +927,7 @@ class JSI_EXPORT WeakObject : public Pointer {
   /// otherwise returns \c undefined.  Note that this method has nothing to do
   /// with threads or concurrency.  The name is based on std::weak_ptr::lock()
   /// which serves a similar purpose.
-  Value lock(Runtime& runtime) const;
+  Value lock(Runtime& runtime) JSI_CONST_10;
 
   friend class Runtime;
 };
@@ -907,7 +963,7 @@ class JSI_EXPORT Array : public Object {
   /// value behaves as with Object::setProperty().  If \c i is out of
   /// range [ 0..\c length ] throws a JSIException.
   template <typename T>
-  void setValueAtIndex(Runtime& runtime, size_t i, T&& value) const;
+  void setValueAtIndex(Runtime& runtime, size_t i, T&& value) JSI_CONST_10;
 
   /// There is no current API for changing the size of an array once
   /// created.  We'll probably need that eventually.
@@ -926,7 +982,7 @@ class JSI_EXPORT Array : public Object {
   friend class Value;
 
   void setValueAtIndexImpl(Runtime& runtime, size_t i, const Value& value)
-      const {
+      JSI_CONST_10 {
     return runtime.setValueAtIndexImpl(*this, i, value);
   }
 
@@ -939,8 +995,10 @@ class JSI_EXPORT ArrayBuffer : public Object {
   ArrayBuffer(ArrayBuffer&&) = default;
   ArrayBuffer& operator=(ArrayBuffer&&) = default;
 
+#if JSI_VERSION >= 9
   ArrayBuffer(Runtime& runtime, std::shared_ptr<MutableBuffer> buffer)
       : ArrayBuffer(runtime.createArrayBuffer(std::move(buffer))) {}
+#endif
 
   /// \return the size of the ArrayBuffer, according to its byteLength property.
   /// (C++ naming convention)
@@ -952,7 +1010,7 @@ class JSI_EXPORT ArrayBuffer : public Object {
     return runtime.size(*this);
   }
 
-  uint8_t* data(Runtime& runtime) const {
+  uint8_t* data(Runtime& runtime) JSI_CONST_10 {
     return runtime.data(*this);
   }
 
@@ -1102,7 +1160,9 @@ class JSI_EXPORT Value {
   /* implicit */ Value(T&& other) : Value(kindOf(other)) {
     static_assert(
         std::is_base_of<Symbol, T>::value ||
+#if JSI_VERSION >= 6
             std::is_base_of<BigInt, T>::value ||
+#endif
             std::is_base_of<String, T>::value ||
             std::is_base_of<Object, T>::value,
         "Value cannot be implicitly move-constructed from this type");
@@ -1125,10 +1185,12 @@ class JSI_EXPORT Value {
     new (&data_.pointer) Symbol(runtime.cloneSymbol(sym.ptr_));
   }
 
+#if JSI_VERSION >= 6
   /// Copies a BigInt lvalue into a new JS value.
   Value(Runtime& runtime, const BigInt& bigint) : Value(BigIntKind) {
     new (&data_.pointer) BigInt(runtime.cloneBigInt(bigint.ptr_));
   }
+#endif
 
   /// Copies a String lvalue into a new JS value.
   Value(Runtime& runtime, const String& str) : Value(StringKind) {
@@ -1165,9 +1227,14 @@ class JSI_EXPORT Value {
 
   // \return a \c Value created from a utf8-encoded JSON string.
   static Value
-  createFromJsonUtf8(Runtime& runtime, const uint8_t* json, size_t length) {
+  createFromJsonUtf8(Runtime& runtime, const uint8_t* json, size_t length)
+#if JSI_VERSION >= 2
+  {
     return runtime.createValueFromJsonUtf8(json, length);
   }
+#else
+      ;
+#endif
 
   /// \return according to the Strict Equality Comparison algorithm, see:
   /// https://262.ecma-international.org/11.0/#sec-strict-equality-comparison
@@ -1199,9 +1266,11 @@ class JSI_EXPORT Value {
     return kind_ == StringKind;
   }
 
+#if JSI_VERSION >= 6
   bool isBigInt() const {
     return kind_ == BigIntKind;
   }
+#endif
 
   bool isSymbol() const {
     return kind_ == SymbolKind;
@@ -1251,6 +1320,7 @@ class JSI_EXPORT Value {
   Symbol asSymbol(Runtime& runtime) const&;
   Symbol asSymbol(Runtime& runtime) &&;
 
+#if JSI_VERSION >= 6
   /// \return the BigInt value, or asserts if not a bigint.
   BigInt getBigInt(Runtime& runtime) const& {
     assert(isBigInt());
@@ -1270,6 +1340,7 @@ class JSI_EXPORT Value {
   /// bigint
   BigInt asBigInt(Runtime& runtime) const&;
   BigInt asBigInt(Runtime& runtime) &&;
+#endif
 
   /// \return the String value, or asserts if not a string.
   String getString(Runtime& runtime) const& {
@@ -1323,7 +1394,9 @@ class JSI_EXPORT Value {
     BooleanKind,
     NumberKind,
     SymbolKind,
+#if JSI_VERSION >= 6
     BigIntKind,
+#endif
     StringKind,
     ObjectKind,
     PointerKind = SymbolKind,
@@ -1350,9 +1423,11 @@ class JSI_EXPORT Value {
   constexpr static ValueKind kindOf(const Symbol&) {
     return SymbolKind;
   }
+#if JSI_VERSION >= 6
   constexpr static ValueKind kindOf(const BigInt&) {
     return BigIntKind;
   }
+#endif
   constexpr static ValueKind kindOf(const String&) {
     return StringKind;
   }

--- a/unittests/API/APITest.cpp
+++ b/unittests/API/APITest.cpp
@@ -107,6 +107,7 @@ TEST_F(HermesRuntimeTest, ArrayBufferTest) {
   EXPECT_EQ(buffer[1], 5678);
 }
 
+#if JSI_VERSION >= 9
 class HermesRuntimeTestMethodsTest : public HermesRuntimeTestBase {
  public:
   HermesRuntimeTestMethodsTest()
@@ -168,6 +169,7 @@ TEST_F(HermesRuntimeTestMethodsTest, ExternalArrayBufferTest) {
     EXPECT_TRUE(weakBuf.expired());
   }
 }
+#endif
 
 TEST_F(HermesRuntimeTest, BytecodeTest) {
   const uint8_t shortBytes[] = {1, 2, 3};
@@ -695,6 +697,7 @@ TEST_F(HermesRuntimeTest, HostObjectAsParentTest) {
       eval("var subClass = {__proto__: ho}; subClass.prop1 == 10;").getBool());
 }
 
+#if JSI_VERSION >= 7
 TEST_F(HermesRuntimeTest, NativeStateTest) {
   class C : public facebook::jsi::NativeState {
    public:
@@ -739,7 +742,9 @@ TEST_F(HermesRuntimeTest, NativeStateTest) {
   // point to local variables. Otherwise ASAN will complain.
   eval("gc()");
 }
+#endif
 
+#if JSI_VERSION >= 5
 TEST_F(HermesRuntimeTest, PropNameIDFromSymbol) {
   auto strProp = PropNameID::forAscii(*rt, "a");
   auto secretProp = PropNameID::forSymbol(
@@ -754,6 +759,7 @@ TEST_F(HermesRuntimeTest, PropNameIDFromSymbol) {
   EXPECT_EQ(x.getProperty(*rt, secretProp).getString(*rt).utf8(*rt), "secret");
   EXPECT_EQ(x.getProperty(*rt, globalProp).getString(*rt).utf8(*rt), "global");
 }
+#endif
 
 TEST_F(HermesRuntimeTest, HasComputedTest) {
   // The only use of JSObject::hasComputed() is in HermesRuntimeImpl,
@@ -867,6 +873,7 @@ TEST_F(HermesRuntimeTest, DiagnosticHandlerTestWarning) {
   EXPECT_EQ(5, diagHandler.ds[1].ranges[0].second);
 }
 
+#if JSI_VERSION >= 8
 TEST_F(HermesRuntimeTest, BigIntJSI) {
   Function bigintCtor = rt->global().getPropertyAsFunction(*rt, "BigInt");
   auto BigInt = [&](const char *v) { return bigintCtor.call(*rt, eval(v)); };
@@ -997,6 +1004,7 @@ TEST_F(HermesRuntimeTest, BigIntJSITruncation) {
   EXPECT_EQ(toUint64(b), lossy(~0ull));
   EXPECT_EQ(toInt64(b), lossy(~0ull));
 }
+#endif
 
 #ifdef HERMESVM_EXCEPTION_ON_OOM
 class HermesRuntimeTestSmallHeap : public HermesRuntimeTestBase {


### PR DESCRIPTION
## Summary

Implement JSI version support by using `JSI_VERSION` macro.

We looked through the history of JSI changes and assigned for each significant change a version number.
The versions with matching GitHub commit hashes are listed in the `README.md` file.
The code is augmented with `#if / #endif` for conditional compilation that make the JSI match the targeted version.

The main goal of this change is to enable use of latest Hermes code with old versions of React Native.
By specifying JSI version we can target React Native version that matches the JSI version used for its release.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/152)