### PR TITLE
React Native Inspector code to match Hermes version.

### DIFF
--- a/API/inspector/CMakeLists.txt
+++ b/API/inspector/CMakeLists.txt
@@ -16,12 +16,11 @@ cmake_print_variables(REACT_NATIVE_SOURCE)
 
 set(inspector_sources
   ${REACT_NATIVE_SOURCE}/ReactCommon/hermes/inspector/Inspector.cpp
-  ${REACT_NATIVE_SOURCE}/ReactCommon/hermes/inspector/Inspector.cpp
   ${REACT_NATIVE_SOURCE}/ReactCommon/hermes/inspector/InspectorState.cpp
   ${REACT_NATIVE_SOURCE}/ReactCommon/hermes/inspector/RuntimeAdapter.cpp
-  ${REACT_NATIVE_SOURCE}/ReactCommon/hermes/inspector/detail/Thread.cpp
-  ${REACT_NATIVE_SOURCE}/ReactCommon/hermes/inspector/detail/SerialExecutor.cpp
   ${REACT_NATIVE_SOURCE}/ReactCommon/hermes/inspector/detail/CallbackOStream.cpp
+  ${REACT_NATIVE_SOURCE}/ReactCommon/hermes/inspector/detail/SerialExecutor.cpp
+  ${REACT_NATIVE_SOURCE}/ReactCommon/hermes/inspector/detail/Thread.cpp
 )
 
 list(APPEND inspector_sources
@@ -31,7 +30,6 @@ list(APPEND inspector_sources
   ${REACT_NATIVE_SOURCE}/ReactCommon/hermes/inspector/chrome/MessageTypes.cpp
   ${REACT_NATIVE_SOURCE}/ReactCommon/hermes/inspector/chrome/Registration.cpp
   ${REACT_NATIVE_SOURCE}/ReactCommon/hermes/inspector/chrome/RemoteObjectsTable.cpp
-  ${REACT_NATIVE_SOURCE}/ReactCommon/hermes/inspector/chrome/AutoAttachUtils.cpp
 )
 
 list(APPEND inspector_sources

--- a/API/inspector/boost/CMakeLists.txt
+++ b/API/inspector/boost/CMakeLists.txt
@@ -29,7 +29,7 @@ foreach(component ${boostComponents})
   FetchContent_Declare(
     boost_${component}
     GIT_REPOSITORY https://github.com/boostorg/${component}.git
-    GIT_TAG        boost-1.72.0
+    GIT_TAG        boost-1.76.0
     GIT_SHALLOW    1
     GIT_PROGRESS   1
   )

--- a/API/inspector/folly/CMakeLists.txt
+++ b/API/inspector/folly/CMakeLists.txt
@@ -4,6 +4,7 @@ FetchContent_Declare(
   folly
   URL      https://github.com/facebook/folly/archive/v2020.01.13.00.tar.gz
   URL_HASH SHA256=b851e02310536cefbbc1e7bbcc2dfedb277bf9f4f87c1bed1dc4d7a22f574fa4
+  DOWNLOAD_EXTRACT_TIMESTAMP true
 )
 
 FetchContent_GetProperties(folly)

--- a/API/inspector/react-native/CMakeLists.txt
+++ b/API/inspector/react-native/CMakeLists.txt
@@ -2,9 +2,9 @@ include(FetchContent)
 
 FetchContent_Declare(
   reactnative
-  GIT_REPOSITORY https://github.com/facebook/react-native.git
-  GIT_TAG        v0.70.0-rc.3
-  GIT_SHALLOW    1
+  URL https://github.com/facebook/react-native/archive/a0800ffc7a676555aa9e769fc8fd6d3162de0ea6.zip
+  URL_HASH SHA256=80a3b89d92a48bd1d39533a6643e4f1390f2ce11db1377a50bd10d557e423857
+  DOWNLOAD_EXTRACT_TIMESTAMP true
 )
 
 FetchContent_GetProperties(reactnative)
@@ -35,29 +35,6 @@ if(NOT reactnative_POPULATED)
     "${file_text}"
   )
   file(WRITE ${reactnative_SOURCE_DIR}/ReactCommon/hermes/inspector/chrome/Registration.h "${file_text}")
-
-  # Fix for https://github.com/microsoft/react-native-windows/issues/9662 (pushed in FB RN per
-  # https://github.com/facebook/react-native/pull/34342). This patch is no longer needed and should be 
-  # removed once the GIT_TAG above contains commit ID 60e7eb4d534298cb9888d5ab0c8b6a6b041dc299.
-  file(READ ${reactnative_SOURCE_DIR}/ReactCommon/hermes/inspector/chrome/ConnectionDemux.cpp file_text)
-  string(REGEX REPLACE 
-    "\n([ \t]*)auto conn = conns_\\.at\\(pageId\\);\n[ \t]*conn->disconnect\\(\\);\n"
-    "\n\\1auto conn = conns_.at(pageId);\n\\1std::string title = conn->getTitle();\n\\1inspectedContexts_->erase(title);\n\\1conn->disconnect();\n"
-    file_text
-    "${file_text}"
-  )
-  file(WRITE ${reactnative_SOURCE_DIR}/ReactCommon/hermes/inspector/chrome/ConnectionDemux.cpp  "${file_text}")
-
-  # Fix for https://github.com/facebook/react-native/issues/34639 (pushed to FB RN per
-  # https://github.com/facebook/react-native/pull/34640).
-  file(READ ${reactnative_SOURCE_DIR}/ReactCommon/hermes/inspector/chrome/Connection.cpp file_text)
-  string(REGEX REPLACE 
-    "\n([ \t]*)// TODO\\(jpporto\\): fix test cases sending invalid context id.\n[ \t]*// note.executionContextId = kHermesExecutionContextId;"
-    "\n\\1note.executionContextId = kHermesExecutionContextId;"
-    file_text
-    "${file_text}"
-  )
-  file(WRITE ${reactnative_SOURCE_DIR}/ReactCommon/hermes/inspector/chrome/Connection.cpp "${file_text}")
 
   file(GLOB_RECURSE YARN_FILES ${reactnative_SOURCE_DIR}/yarn.lock ${reactnative_SOURCE_DIR}/**/yarn.lock)
   message("Removing unused yarn.lock files: ${YARN_FILES}")


### PR DESCRIPTION
## Summary

Hermes-windows builds `hermesinspector.dll` for JavaScript debugging using Chrome protocol.
The code for the Inspector is taken from the corresponding version of React Native code.
The Inspector code is kept separately from Hermes code mostly to avoid extra dependencies and to make the code lightweight.

This PR brings RN Inspector code with the RN commit hash that matches the Hermes version.
Ideally, we must change the RN commit hash every time we acquire new Hermes code.

In this PR we also do the following changes:
- Remove duplicated use of `Inspector.cpp`
- Remove dependency on `AutoAttachUtils.cpp` because it was removed in RN code. It was casing 2 minutes delay for debugger attaching.
- Add `DOWNLOAD_EXTRACT_TIMESTAMP true` to suppress CMake warning that suggests using this flag.
- Update Boost version to 1.76 to match the version used by RN.
- Removed patching `ConnectionDemux.cpp` and `Connection.cpp` files since they are already updated in that version of RN

Note that we could not move to the matching version of Folly because it has too many additional dependencies.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/hermes-windows/pull/153)