### PR TITLE
Remove juno folder prior to build during CI to silence CG alerts.

### DIFF
--- a/.ado/scripts/cibuild.ps1
+++ b/.ado/scripts/cibuild.ps1
@@ -108,6 +108,10 @@ function Get-CMakeConfiguration($config) {
     return $val
 }
 
+function Invoke-RemoveUnusedFilesForComponentGovernance() {
+    Remove-Item -Path ".\unsupported" -Force -Recurse
+}
+
 function Invoke-Environment($Command, $arg) {
     $Command = "`"" + $Command + "`" " + $arg
     Write-Host "Running command [ $Command ]"
@@ -453,7 +457,7 @@ function Invoke-PrepareNugetPackage($SourcesPath, $WorkSpacePath, $OutputPath, $
     $npmPackage | Set-Content "$OutputPath\version"
 }
 
-
+Invoke-RemoveUnusedFilesForComponentGovernance
 $StartTime = (Get-Date)
 
 $VCVARS_PATH = Find-VS-Path

--- a/.ado/scripts/cibuild.ps1
+++ b/.ado/scripts/cibuild.ps1
@@ -109,7 +109,7 @@ function Get-CMakeConfiguration($config) {
 }
 
 function Invoke-RemoveUnusedFilesForComponentGovernance() {
-    Remove-Item -Path ".\unsupported" -Force -Recurse
+    Remove-Item -Path ".\unsupported\juno" -Force -Recurse
 }
 
 function Invoke-Environment($Command, $arg) {


### PR DESCRIPTION
There's an unsupported rust tool called `juno` under the folder `unsupported`, which checks in a `cargo.lock` file that is causing component governance alerts. The `juno` folder is not touched during build whatsoever, so to silence component governance, we remove that folder before executing build. If the juno tool does become supported at some point, we can revisit this.