### PR TITLE
Introducing Microsoft.JavaScript.Hermes.Fat nuspec (includes .pdb symbol files)

### DIFF
--- a/.ado/Microsoft.JavaScript.Hermes.Fat.nuspec
+++ b/.ado/Microsoft.JavaScript.Hermes.Fat.nuspec
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.JavaScript.Hermes.Fat</id>
+    <version>$Version$</version>
+    <description>Hermes JavaScript engine (VERSION_DETAILS)</description>
+    <authors>Microsoft</authors>
+    <projectUrl>https://github.com/microsoft/hermes-windows</projectUrl>
+    <license type="expression">MIT</license>
+    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
+    <repository type="git" url="$RepoUri$" commit="$CommitId$" />
+    <tags>native Hermes JavaScript JS engine NodeAPI Node-API NAPI</tags>
+  </metadata>
+  <files>
+    <file src="$nugetroot$\lib\native\uwp\release\arm64\**\*.*"
+          target="build\native\uwp\arm64"
+          exclude="**\*.manifest;**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\lib\native\uwp\release\x64\**\*.*"
+          target="build\native\uwp\x64"
+          exclude="**\*.manifest;**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\lib\native\uwp\release\x86\**\*.*"
+          target="build\native\uwp\x86"
+          exclude="**\*.manifest;**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\lib\native\win32\release\arm64\**\*.*"
+          target="build\native\win32\arm64"
+          exclude="**\*.manifest;**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\lib\native\win32\release\x64\**\*.*"
+          target="build\native\win32\x64"
+          exclude="**\*.manifest;**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\lib\native\win32\release\x86\**\*.*"
+          target="build\native\win32\x86"
+          exclude="**\*.manifest;**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\lib\uap\_._" target="build\uap\_._" />
+
+    <file src="$nugetroot$\build\native\include\**\*.*"
+          target="build\native\include" />
+    <file src="$nugetroot$\build\native\Microsoft.JavaScript.Hermes.targets"
+          target="build\native\Microsoft.JavaScript.Hermes.targets" />
+
+    <file src="$nugetroot$\license\*" target="" />
+    <file src="$nugetroot$\tools\**\*.*" target="tools" />
+  </files>
+</package>

--- a/.ado/Microsoft.JavaScript.Hermes.targets
+++ b/.ado/Microsoft.JavaScript.Hermes.targets
@@ -4,7 +4,7 @@
     <!-- Fix platform name (win32 should be x86) -->
     <HermesPlatform Condition="'$(HermesPlatform)' == 'Win32'">x86</HermesPlatform>
 
-    <HermesAppPlatform Condition="'$(HermesAppPlatform)' == ''and '$(AppContainerApplication)' == 'true'">uwp</HermesAppPlatform>
+    <HermesAppPlatform Condition="'$(HermesAppPlatform)' == '' and '$(AppContainerApplication)' == 'true'">uwp</HermesAppPlatform>
     <HermesAppPlatform Condition="'$(HermesAppPlatform)' == ''">win32</HermesAppPlatform>
 
     <NugetRoot>$(MSBuildThisFileDirectory)..\..\</NugetRoot>

--- a/.ado/Microsoft.JavaScript.Hermes.targets
+++ b/.ado/Microsoft.JavaScript.Hermes.targets
@@ -4,7 +4,7 @@
     <!-- Fix platform name (win32 should be x86) -->
     <HermesPlatform Condition="'$(HermesPlatform)' == 'Win32'">x86</HermesPlatform>
 
-    <HermesAppPlatform Condition="'$(HermesAppPlatform)' == ''">$(AppPlatform)</HermesAppPlatform>
+    <HermesAppPlatform Condition="'$(HermesAppPlatform)' == ''and '$(AppContainerApplication)' == 'true'">uwp</HermesAppPlatform>
     <HermesAppPlatform Condition="'$(HermesAppPlatform)' == ''">win32</HermesAppPlatform>
 
     <NugetRoot>$(MSBuildThisFileDirectory)..\..\</NugetRoot>

--- a/.ado/jobs.yml
+++ b/.ado/jobs.yml
@@ -170,6 +170,16 @@ jobs:
           versioningScheme: byEnvVar
           versionEnvVar: Version
 
+      - task: NuGetCommand@2
+        displayName: 'NuGet Fat Pack'
+        inputs:
+          command: pack
+          packagesToPack: $(System.DefaultWorkingDirectory)\HermesArtifacts\Microsoft.JavaScript.Hermes.Fat.nuspec
+          packDestination: $(System.DefaultWorkingDirectory)\NugetRootFinal
+          buildProperties: CommitId=$(Build.SourceVersion);nugetroot=$(System.DefaultWorkingDirectory)\HermesArtifacts;RepoUri=$(Build.Repository.Uri)
+          versioningScheme: byEnvVar
+          versionEnvVar: Version
+
       - ${{ if parameters.isPublish }}:
         - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
           displayName: CodeSign NuGets
@@ -179,6 +189,7 @@ jobs:
             FolderPath: $(System.DefaultWorkingDirectory)\NugetRootFinal
             Pattern: |
               **/Microsoft.JavaScript.Hermes.*.nupkg
+              **/Microsoft.JavaScript.Hermes.Fat.*.nupkg
             UseMinimatch: true
             signConfigType: inlineSignParams
             inlineOperation: |
@@ -204,7 +215,7 @@ jobs:
           condition: not(eq(variables['Build.Reason'], 'PullRequest'))
           inputs:
             BuildDropPath: $(System.DefaultWorkingDirectory)\NugetRootFinal
-  
+
         - task: PublishBuildArtifacts@1
           displayName: "Publish final nuget artifacts"
           inputs:

--- a/.ado/scripts/cibuild.ps1
+++ b/.ado/scripts/cibuild.ps1
@@ -384,7 +384,8 @@ function Invoke-PrepareNugetPackage($SourcesPath, $WorkSpacePath, $OutputPath, $
     $npmPackage = (Get-Content (Join-Path $SourcesPath "npm\package.json") | Out-String | ConvertFrom-Json).version
 
     (Get-Content "$SourcesPath\.ado\Microsoft.JavaScript.Hermes.nuspec") -replace ('VERSION_DETAILS', "Hermes version: $npmPackage; Git revision: $gitRevision") | Set-Content "$OutputPath\Microsoft.JavaScript.Hermes.nuspec"
-
+    (Get-Content "$SourcesPath\.ado\Microsoft.JavaScript.Hermes.Fat.nuspec") -replace ('VERSION_DETAILS', "Hermes version: $npmPackage; Git revision: $gitRevision") | Set-Content "$OutputPath\Microsoft.JavaScript.Hermes.Fat.nuspec"
+    
     $npmPackage | Set-Content "$OutputPath\version"
 }
 


### PR DESCRIPTION
…bol files)

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary
Current ABI-Hermes package excludes *.pbd files in its packaging. This introduces a fat nuspec that includes the symbols `Microsoft.JavaScript.Hermes.Fat`.  Change also includes removing `AppPlatform` and defaulting uwp to conditional check on AppContainerApplication in hermes.targets file.

## Test Plan

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
