### PR TITLE
Fix Hermes GC memory leaks

### DIFF
--- a/lib/Support/OSCompatWindows.cpp
+++ b/lib/Support/OSCompatWindows.cpp
@@ -280,7 +280,9 @@ llvh::ErrorOr<void *> vm_commit(void *p, size_t sz) {
   return result;
 }
 
-void vm_uncommit(void *, size_t) {}
+void vm_uncommit(void *p, size_t sz) {
+  VirtualFree(p, sz, MEM_DECOMMIT);
+}
 
 void vm_hugepage(void *p, size_t sz) {
   assert(

--- a/lib/VM/JSWeakMapImpl.cpp
+++ b/lib/VM/JSWeakMapImpl.cpp
@@ -291,6 +291,7 @@ CallResult<uint32_t> JSWeakMapImplBase::getFreeValueStorageIndex(
             ExecutionStatus::EXCEPTION)) {
       return ExecutionStatus::EXCEPTION;
     }
+    self->valueStorage_.setNonNull(runtime, *storageHandle, runtime.getHeap());
   }
 
   // Update internal state here to ensure we don't corrupt it on exception.
@@ -303,8 +304,6 @@ CallResult<uint32_t> JSWeakMapImplBase::getFreeValueStorageIndex(
   }
 
   assert(i < storageHandle->size(runtime) && "invalid index");
-  self->valueStorage_.setNonNull(runtime, *storageHandle, runtime.getHeap());
-
   return i;
 }
 

--- a/test/hermes/weakmap-cycle.js
+++ b/test/hermes/weakmap-cycle.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -gc-max-heap=32M %s
+// REQUIRES: !slow_debug
+
+(function () {
+    var foo = new WeakMap();
+
+    for (var i = 0; i < 1000000; i++) {
+        var x = {};
+        foo.set(x, x);
+    }
+})();


### PR DESCRIPTION
There are two different fixes:
- Implement `vm_uncommit` for Windows platforms. This change affect only x64 platform where the virtual memory was never uncommitted.
- Cherry pick Hermes commit https://github.com/facebook/hermes/commit/e7b2abefabb6a9671e1d30d7af08cd1f32c9a670 that fixes the memory leak issue where we did not see host objects being deleted.