### PR TITLE
Fix access to finalizer queue from a GC background thread

### DIFF
--- a/unittests/NAPI/CMakeLists.txt
+++ b/unittests/NAPI/CMakeLists.txt
@@ -30,6 +30,7 @@ set(NAPITests
   test_error.cpp
   test_exception.cpp
   test_ext.cpp
+  test_finalizer.cpp
   test_function.cpp
   test_general.cpp
   test_handle_scope.cpp

--- a/unittests/NAPI/js-native-api/test_finalizer/binding.gyp
+++ b/unittests/NAPI/js-native-api/test_finalizer/binding.gyp
@@ -1,0 +1,11 @@
+{
+  "targets": [
+    {
+      "target_name": "test_finalizer",
+      "sources": [
+        "../entry_point.c",
+        "test_finalizer.c"
+      ]
+    }
+  ]
+}

--- a/unittests/NAPI/js-native-api/test_finalizer/test.js
+++ b/unittests/NAPI/js-native-api/test_finalizer/test.js
@@ -1,0 +1,43 @@
+'use strict';
+// Flags: --expose-gc
+
+const { gcUntil, buildType } = require('../../common');
+const assert = require('assert');
+
+const test_finalizer = require(`./build/${buildType}/test_finalizer`);
+
+// This test script uses external values with finalizer callbacks
+// in order to track when values get garbage-collected. Each invocation
+// of a finalizer callback increments the finalizeCount property.
+assert.strictEqual(test_finalizer.finalizeCount, 0);
+
+let objects = [];
+
+function createObjects() {
+  objects = [];
+  for (let i = 0; i < 50000; i++) {
+    const obj = new Object();
+    test_finalizer.addPropertyWithFinalizer(obj);
+    objects.push(obj);
+  }
+}
+
+createObjects();
+
+function runNextTick() {
+  return new Promise((resolve, _) => {
+    setImmediate(() => {
+      resolve();
+    });
+  });
+}
+
+async function waitForBGGC() {
+  for (let i = 0; i < 2; ++i) {
+    await runNextTick();
+    createObjects();
+  }
+}
+
+waitForBGGC();
+

--- a/unittests/NAPI/js-native-api/test_finalizer/test_finalizer.c
+++ b/unittests/NAPI/js-native-api/test_finalizer/test_finalizer.c
@@ -1,0 +1,72 @@
+#include <assert.h>
+#include <js_native_api.h>
+#include <stdlib.h>
+#include "../common.h"
+
+static int test_value = 1;
+static int finalize_count = 0;
+
+static napi_value GetFinalizeCount(napi_env env, napi_callback_info info) {
+  napi_value result;
+  NODE_API_CALL(env, napi_create_int32(env, finalize_count, &result));
+  return result;
+}
+
+static void FinalizeExternal(napi_env env, void *data, void *hint) {
+  int *actual_value = (int *)data;
+  NODE_API_ASSERT_RETURN_VOID(
+      env,
+      actual_value == &test_value,
+      "The correct pointer was passed to the finalizer");
+  finalize_count++;
+}
+
+static napi_value AddPropertyWithFinalizer(
+    napi_env env,
+    napi_callback_info info) {
+  size_t argc = 1;
+  napi_value arg;
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &arg, NULL, NULL));
+
+  NODE_API_ASSERT(env, argc == 1, "Expected one argument.");
+
+  napi_valuetype argtype;
+  NODE_API_CALL(env, napi_typeof(env, arg, &argtype));
+
+  NODE_API_ASSERT(env, argtype == napi_object, "Expected an object value.");
+
+  napi_value external_value;
+  NODE_API_CALL(
+      env,
+      napi_create_external(
+          env,
+          &test_value,
+          FinalizeExternal,
+          NULL, /* finalize_hint */
+          &external_value));
+
+  NODE_API_CALL(
+      env, napi_set_named_property(env, arg, "External", external_value));
+
+  return NULL;
+}
+
+EXTERN_C_START
+napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor descriptors[] = {
+      DECLARE_NODE_API_GETTER("finalizeCount", GetFinalizeCount),
+      DECLARE_NODE_API_PROPERTY(
+          "addPropertyWithFinalizer", AddPropertyWithFinalizer),
+  };
+
+  NODE_API_CALL(
+      env,
+      napi_define_properties(
+          env,
+          exports,
+          sizeof(descriptors) / sizeof(*descriptors),
+          descriptors));
+
+  return exports;
+}
+EXTERN_C_END

--- a/unittests/NAPI/js/CMakeLists.txt
+++ b/unittests/NAPI/js/CMakeLists.txt
@@ -18,6 +18,7 @@ set(testJSFiles
   test_error/test.js
   test_exception/test.js
   test_exception/testFinalizerException.js
+  test_finalizer/test.js
   test_function/test.js
   test_general/test.js
   test_general/testEnvCleanup.js

--- a/unittests/NAPI/napitest.h
+++ b/unittests/NAPI/napitest.h
@@ -92,14 +92,14 @@ struct NapiTest : ::testing::TestWithParam<NapiTestData> {
       std::function<void(NapiTestContext *, napi_env)> code) noexcept;
 };
 
-// Properies from JavaScript Error object.
+// Properties from JavaScript Error object.
 struct NapiErrorInfo {
   std::string Name;
   std::string Message;
   std::string Stack;
 };
 
-// Properies from JavaScript AssertionError object.
+// Properties from JavaScript AssertionError object.
 struct NapiAssertionErrorInfo {
   std::string Method;
   std::string Expected;

--- a/unittests/NAPI/test_finalizer.cpp
+++ b/unittests/NAPI/test_finalizer.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "napitest.h"
+
+#define Init test_finalizer_init
+#include "js-native-api/test_finalizer/test_finalizer.c"
+
+using namespace napitest;
+
+TEST_P(NapiTest, test_finalizer) {
+  ExecuteNapi([](NapiTestContext *testContext, napi_env env) {
+    testContext->AddNativeModule(
+        "./build/x86/test_finalizer",
+        [](napi_env env, napi_value exports) { return Init(env, exports); });
+    testContext->RunTestScript("test_finalizer/test.js");
+  });
+}


### PR DESCRIPTION
The `NapiExternalValue` destructor can be called either from JS or GC background threads by Hermes GC.
In case if it is called from a GC background thread we are getting the race condition because `NapiExternalValue` destructor adds its finalizers to the `NapiEnvironment` finalizer queue. While the finalizer queue is meant to be accessed only from a JS threrad.

This PR fixes the issue by adding a new `NapiPendingFinalizers` class that is ref counted and referenced from `NapiEnvironment` and all `NapiExternalValue` objects.
A `NapiExternalValue` destructor adds finalizers to the `NapiPendingFinalizers` instance under a lock.
Then, `NapiEnvironment` pulls the finalizers under the lock from the `NapiPendingFinalizers` to the finalizer queue in JS thread.
It ensures that the finalizer queue is only accessed from the JS thread.

The new `napi_finalizer` test is added, but it only re-creates a condition when the GC uses background thread. It does not do any actual checks.