### PR TITLE
Build arm64ec version of hermes.dll

### DIFF
--- a/.ado/Microsoft.JavaScript.Hermes.Fat.nuspec
+++ b/.ado/Microsoft.JavaScript.Hermes.Fat.nuspec
@@ -24,6 +24,9 @@
     <file src="$nugetroot$\lib\native\win32\release\arm64\**\*.*"
           target="build\native\win32\arm64"
           exclude="**\*.manifest;**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\lib\native\win32\release\arm64ec\**\*.*"
+          target="build\native\win32\arm64ec"
+          exclude="**\*.manifest;**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
     <file src="$nugetroot$\lib\native\win32\release\x64\**\*.*"
           target="build\native\win32\x64"
           exclude="**\*.manifest;**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />

--- a/.ado/Microsoft.JavaScript.Hermes.nuspec
+++ b/.ado/Microsoft.JavaScript.Hermes.nuspec
@@ -24,6 +24,9 @@
     <file src="$nugetroot$\lib\native\win32\release\arm64\**\*.*"
           target="build\native\win32\arm64"
           exclude="**\*.manifest;**\*.iobj;**\*.ipdb;**\*.pdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\lib\native\win32\release\arm64ec\**\*.*"
+          target="build\native\win32\arm64ec"
+          exclude="**\*.manifest;**\*.iobj;**\*.ipdb;**\*.pdb;**\*.exp;**\*.ilk" />
     <file src="$nugetroot$\lib\native\win32\release\x64\**\*.*"
           target="build\native\win32\x64"
           exclude="**\*.manifest;**\*.iobj;**\*.ipdb;**\*.pdb;**\*.exp;**\*.ilk" />

--- a/.ado/jobs.yml
+++ b/.ado/jobs.yml
@@ -36,6 +36,10 @@ jobs:
           BuildConfiguration: release
           BuildPlatform: arm64
           BuildAppPlatform: win32
+        ReleaseArm64ECWin32:
+          BuildConfiguration: release
+          BuildPlatform: arm64ec
+          BuildAppPlatform: win32
     variables:
       semanticVersion: $[ dependencies.Setup.outputs['setVersions.semanticVersion'] ]
       fileVersion: $[ dependencies.Setup.outputs['setVersions.fileVersion'] ]

--- a/.ado/scripts/cibuild.ps1
+++ b/.ado/scripts/cibuild.ps1
@@ -269,6 +269,11 @@ function Invoke-Dll-Build($SourcesPath, $buildPath, $compilerAndToolsBuildPath, 
         $genArgs += "-DIMPORT_HERMESC=$compilerAndToolsBuildPath\ImportHermesc.cmake"
     }
 
+    if ($Platform -eq "arm64ec") {
+        $Env:CFLAGS = "-arm64EC"
+        $Env:CXXFLAGS = "-arm64EC"
+    }
+
     Invoke-BuildImpl $SourcesPath $buildPath $genArgs $targets $incrementalBuild $Platform $Configuration $AppPlatform
 }
 
@@ -392,11 +397,6 @@ function Invoke-PrepareNugetPackage($SourcesPath, $WorkSpacePath, $OutputPath, $
 
 Invoke-RemoveUnusedFilesForComponentGovernance
 $StartTime = (Get-Date)
-
-if ($Platform -eq "arm64ec") {
-    $Env:CFLAGS = "-arm64EC"
-    $Env:CXXFLAGS = "-arm64EC"
-}
 
 $VCVARS_PATH = Find-VS-Path
 

--- a/.ado/scripts/cibuild.ps1
+++ b/.ado/scripts/cibuild.ps1
@@ -264,7 +264,7 @@ function Invoke-Dll-Build($SourcesPath, $buildPath, $compilerAndToolsBuildPath, 
         $genArgs += '-DCMAKE_SYSTEM_NAME=WindowsStore'
         $genArgs += '-DCMAKE_SYSTEM_VERSION="10.0.17763.0"'
         $genArgs += "-DIMPORT_HERMESC=$compilerAndToolsBuildPath\ImportHermesc.cmake"
-    } elseif ($Platform -eq "arm64" || $Platform -eq "arm64ec") {
+    } elseif ($Platform -eq "arm64" -or $Platform -eq "arm64ec") {
         $genArgs += '-DHERMES_MSVC_ARM64=On'
         $genArgs += "-DIMPORT_HERMESC=$compilerAndToolsBuildPath\ImportHermesc.cmake"
     }
@@ -281,7 +281,7 @@ function Invoke-Test-Build($SourcesPath, $buildPath, $compilerAndToolsBuildPath,
     if ($AppPlatform -eq "uwp") {
         $genArgs += '-DCMAKE_SYSTEM_NAME=WindowsStore'
         $genArgs += '-DCMAKE_SYSTEM_VERSION="10.0.17763"'
-    } elseif ($Platform -eq "arm64" || $Platform -eq "arm64ec") {
+    } elseif ($Platform -eq "arm64" -or $Platform -eq "arm64ec") {
         $genArgs += '-DHERMES_MSVC_ARM64=On'
         $genArgs += "-DIMPORT_HERMESC=$compilerAndToolsBuildPath\ImportHermesc.cmake"
     }

--- a/.ado/scripts/cibuild.ps1
+++ b/.ado/scripts/cibuild.ps1
@@ -3,7 +3,7 @@ param(
     [string]$WorkSpacePath = "$SourcesPath\workspace",
     [string]$OutputPath = "$WorkSpacePath\out",
     
-    [ValidateSet("x64", "x86", "arm64")]
+    [ValidateSet("x64", "x86", "arm64", "arm64ec")]
     [String[]]$Platform = @("x64"),
 
     [ValidateSet("x64", "x86", "arm64")]
@@ -83,6 +83,7 @@ function Get-VCVarsParam($plat = "x64", $arch = "win32") {
         "x64" {"x64"}
         "x86" {"x64_x86"}
         "arm64" {"x64_arm64"}
+        "arm64ec" {"x64_arm64"}
         default { "x64" }
     }
 
@@ -263,7 +264,7 @@ function Invoke-Dll-Build($SourcesPath, $buildPath, $compilerAndToolsBuildPath, 
         $genArgs += '-DCMAKE_SYSTEM_NAME=WindowsStore'
         $genArgs += '-DCMAKE_SYSTEM_VERSION="10.0.17763.0"'
         $genArgs += "-DIMPORT_HERMESC=$compilerAndToolsBuildPath\ImportHermesc.cmake"
-    } elseif ($Platform -eq "arm64") {
+    } elseif ($Platform -eq "arm64" || $Platform -eq "arm64ec") {
         $genArgs += '-DHERMES_MSVC_ARM64=On'
         $genArgs += "-DIMPORT_HERMESC=$compilerAndToolsBuildPath\ImportHermesc.cmake"
     }
@@ -280,7 +281,7 @@ function Invoke-Test-Build($SourcesPath, $buildPath, $compilerAndToolsBuildPath,
     if ($AppPlatform -eq "uwp") {
         $genArgs += '-DCMAKE_SYSTEM_NAME=WindowsStore'
         $genArgs += '-DCMAKE_SYSTEM_VERSION="10.0.17763"'
-    } elseif ($Platform -eq "arm64") {
+    } elseif ($Platform -eq "arm64" || $Platform -eq "arm64ec") {
         $genArgs += '-DHERMES_MSVC_ARM64=On'
         $genArgs += "-DIMPORT_HERMESC=$compilerAndToolsBuildPath\ImportHermesc.cmake"
     }
@@ -391,6 +392,11 @@ function Invoke-PrepareNugetPackage($SourcesPath, $WorkSpacePath, $OutputPath, $
 
 Invoke-RemoveUnusedFilesForComponentGovernance
 $StartTime = (Get-Date)
+
+if ($Platform -eq "arm64ec") {
+    $Env:CFLAGS = "-arm64EC"
+    $Env:CXXFLAGS = "-arm64EC"
+}
 
 $VCVARS_PATH = Find-VS-Path
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->
Office on Windows on Arm64 uses the Arm64EC ABI, an ABI that is compatible with x64 allowing it to interop with x64 binaries. Arm64EC is **NOT** compatible with Arm64 native. Currently, Office is running the x64 version of hermes.dll, which leads to paying the cost of emulation. If instead, we produce an Arm64EC version, we can get near native performance with minimal overhead. This change adds the build logic needed to produce the Arm64EC version of hermes.dll.

## Test Plan

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
I ran `link /dump /headers <path to Arm64EC hermes.dll> | grep "machine"` and verified that the dll is "8664 machine (x64) (ARM64X)", or Arm64EC.

I will be locally testing the Arm64EC version of hermes.dll in Office on Windows, Arm64 to ensure that everything still works and will measure the performance impact in executing a scenario.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/185)