### PR TITLE
Fix the CI BinSkim issues

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -146,6 +146,24 @@ if(APPLE AND HERMES_BUILD_APPLE_FRAMEWORK)
   endif()
 endif()
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+  # Same as above, but for windows. Note that there is no equivalent of -fvisibility=default.
+  set(compile_flags "")
+
+  # Enable exeption
+  set(compile_flags "${compile_flags} /EHsc")
+
+  # Enable RTTI
+  set(compile_flags "${compile_flags} /GR")
+
+  # Generate PDBs
+  set(compile_flags "${compile_flags} /Zi")
+endif()
+
+set_target_properties(libhermes PROPERTIES
+  COMPILE_FLAGS "${compile_flags}"
+)
+
 install(TARGETS libhermes
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib


### PR DESCRIPTION
Currently Ci fails because `libhermes` is not compiled with the right compiler flags.
In this PR we restore the same flags as we used to have them before we split up `libshared`.

It is not possible to repro the issue locally. Thus, the PR is made in the hope that it passes.
I did a verification based on the test branch, but the main branch verification could be different.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/194)