### PR TITLE
Increase the build timeout to 300 minutes

### DIFF
--- a/.ado/build-template.yml
+++ b/.ado/build-template.yml
@@ -124,7 +124,7 @@ extends:
           dependsOn:
           - Set_Versions
 
-          timeoutInMinutes: 120
+          timeoutInMinutes: 300
 
           variables:
           - name: semanticVersion


### PR DESCRIPTION
Our CI build may fail because the CodeQL injection significantly increases the build time.
This PR changes the timeout to 5 hours instead of 2 hours.