### PR TITLE
Mark use of SHA1 algorithm as for non-security code

### DIFF
--- a/utils/genUnicodeTable.py
+++ b/utils/genUnicodeTable.py
@@ -57,7 +57,7 @@ class UnicodeDataFiles:
         if filename not in cls.__cache:
             data = cls.__local_or_fetch(cls.URLS[filename], filename)
             cls.__cache[filename] = {
-                "sha1": hashlib.sha1(data).hexdigest(),
+                "sha1": hashlib.sha1(data).hexdigest(), # nosec
                 "lines": cls.__data_to_lines(data),
             }
         return cls.__cache[filename]


### PR DESCRIPTION
The previous PR #204 broke the CI SDL check.
The SDL Guardian found use of SHA1 algorithm in the Python script `utils/genUnicodeTable.py`.
In this PR we mark that code with `# nosec` to indicate that this code does not use the SHA1 algorithm for security purposes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/206)