### PR TITLE
JSI version Cleanup

### DIFF
--- a/API/hermes/TimerStats.cpp
+++ b/API/hermes/TimerStats.cpp
@@ -263,12 +263,10 @@ class TimedRuntime final : public jsi::RuntimeDecorator<jsi::Runtime> {
     return RD::callAsConstructor(func, args, count);
   }
 
-#if JSI_VERSION >= 4
   bool drainMicrotasks(int maxMicrotasksHint) override {
     auto timer = rts_.incomingTimer("drainMicrotasks");
     return RD::drainMicrotasks(maxMicrotasksHint);
   }
-#endif
   /// @}
 
  private:

--- a/API/hermes/TraceInterpreter.cpp
+++ b/API/hermes/TraceInterpreter.cpp
@@ -328,9 +328,7 @@ Value traceValueToJSIValue(
     return Value(value.getBool());
   }
   if (value.isObject() ||
-#if JSI_VERSION >= 8
       value.isBigInt() ||
-#endif
       value.isString() || value.isSymbol()) {
     return getJSIValueForUse(value.getUID());
   }
@@ -875,11 +873,7 @@ std::string TraceInterpreter::execEntryFunction(
   return stats_;
 }
 
-#if JSI_VERSION >= 8
 #define VAL_IS_BIGINT val.isBigInt() ||
-#else
-#define VAL_IS_BIGINT
-#endif
 
 Value TraceInterpreter::execFunction(
     const TraceInterpreter::Call &call,
@@ -1067,7 +1061,6 @@ Value TraceInterpreter::execFunction(
             break;
           }
           case RecordType::CreateBigInt: {
-#if JSI_VERSION >= 8
             const auto &cbr =
                 static_cast<const SynthTrace::CreateBigIntRecord &>(*rec);
             Value bigint;
@@ -1086,13 +1079,9 @@ Value TraceInterpreter::execFunction(
             }
             addJSIValueToDefs(
                 call, cbr.objID_, globalRecordNum, std::move(bigint), locals);
-#else
-            throw std::runtime_error("jsi::BigInt is not supported");
-#endif
             break;
           }
           case RecordType::BigIntToString: {
-#if JSI_VERSION >= 8
             const auto &bts =
                 static_cast<const SynthTrace::BigIntToStringRecord &>(*rec);
             BigInt obj = getJSIValueForUse(bts.bigintID_).asBigInt(rt_);
@@ -1102,9 +1091,6 @@ Value TraceInterpreter::execFunction(
                 globalRecordNum,
                 obj.toString(rt_, bts.radix_),
                 locals);
-#else
-            throw std::runtime_error("jsi::BigInt is not supported");
-#endif
             break;
           }
           case RecordType::CreateString: {
@@ -1143,12 +1129,7 @@ Value TraceInterpreter::execFunction(
                   auto val = traceValueToJSIValue(
                       rt_, trace_, getJSIValueForUse, cpnr.traceValue_);
                   if (val.isSymbol())
-#if JSI_VERSION >= 5
                     return PropNameID::forSymbol(rt_, val.getSymbol(rt_));
-#else
-                    throw std::runtime_error(
-                        "PropNameID::forSymbol is not supported");
-#endif
                   return PropNameID::forString(rt_, val.getString(rt_));
                 }
               }
@@ -1189,25 +1170,17 @@ Value TraceInterpreter::execFunction(
             break;
           }
           case RecordType::QueueMicrotask: {
-#if JSI_VERSION >= 12
             const auto &queueRecord =
                 static_cast<const SynthTrace::QueueMicrotaskRecord &>(*rec);
             jsi::Function callback =
                 getObjForUse(queueRecord.callbackID_).asFunction(rt_);
             rt_.queueMicrotask(callback);
-#else
-            throw std::runtime_error("queueMicrotask is not supported");
-#endif
             break;
           }
           case RecordType::DrainMicrotasks: {
-#if JSI_VERSION >= 4
             const auto &drainRecord =
                 static_cast<const SynthTrace::DrainMicrotasksRecord &>(*rec);
             rt_.drainMicrotasks(drainRecord.maxMicrotasksHint_);
-#else
-            throw std::runtime_error("drainMicrotasks is not supported");
-#endif
             break;
           }
           case RecordType::GetProperty: {

--- a/API/hermes/TracingRuntime.cpp
+++ b/API/hermes/TracingRuntime.cpp
@@ -185,22 +185,18 @@ jsi::Value TracingRuntime::evaluateJavaScript(
   return res;
 }
 
-#if JSI_VERSION >= 12
 void TracingRuntime::queueMicrotask(const jsi::Function &callback) {
   RD::queueMicrotask(callback);
   trace_.emplace_back<SynthTrace::QueueMicrotaskRecord>(
       getTimeSinceStart(), getUniqueID(callback));
 }
-#endif
 
-#if JSI_VERSION >= 4
 bool TracingRuntime::drainMicrotasks(int maxMicrotasksHint) {
   auto res = RD::drainMicrotasks(maxMicrotasksHint);
   trace_.emplace_back<SynthTrace::DrainMicrotasksRecord>(
       getTimeSinceStart(), maxMicrotasksHint);
   return res;
 };
-#endif
 
 jsi::Object TracingRuntime::createObject() {
   auto obj = RD::createObject();
@@ -326,7 +322,6 @@ jsi::Object TracingRuntime::createObject(std::shared_ptr<jsi::HostObject> ho) {
   return obj;
 }
 
-#if JSI_VERSION >= 8
 jsi::BigInt TracingRuntime::createBigIntFromInt64(int64_t value) {
   jsi::BigInt res = RD::createBigIntFromInt64(value);
   trace_.emplace_back<SynthTrace::CreateBigIntRecord>(
@@ -355,7 +350,6 @@ jsi::String TracingRuntime::bigintToString(
       getTimeSinceStart(), getUniqueID(res), getUniqueID(bigint), radix);
   return res;
 }
-#endif
 
 jsi::String TracingRuntime::createStringFromAscii(
     const char *str,
@@ -403,7 +397,6 @@ jsi::PropNameID TracingRuntime::createPropNameIDFromString(
   return res;
 }
 
-#if JSI_VERSION >= 5
 jsi::PropNameID TracingRuntime::createPropNameIDFromSymbol(
     const jsi::Symbol &sym) {
   jsi::PropNameID res = RD::createPropNameIDFromSymbol(sym);
@@ -413,7 +406,6 @@ jsi::PropNameID TracingRuntime::createPropNameIDFromSymbol(
       SynthTrace::encodeSymbol(getUniqueID(sym)));
   return res;
 }
-#endif
 
 jsi::Value TracingRuntime::getProperty(
     const jsi::Object &obj,
@@ -476,7 +468,7 @@ bool TracingRuntime::hasProperty(
 }
 
 void TracingRuntime::setPropertyValue(
-    JSI_CONST_10 jsi::Object &obj,
+    const jsi::Object &obj,
     const jsi::String &name,
     const jsi::Value &value) {
   trace_.emplace_back<SynthTrace::SetPropertyRecord>(
@@ -491,7 +483,7 @@ void TracingRuntime::setPropertyValue(
 }
 
 void TracingRuntime::setPropertyValue(
-    JSI_CONST_10 jsi::Object &obj,
+    const jsi::Object &obj,
     const jsi::PropNameID &name,
     const jsi::Value &value) {
   trace_.emplace_back<SynthTrace::SetPropertyRecord>(
@@ -537,7 +529,7 @@ jsi::WeakObject TracingRuntime::createWeakObject(const jsi::Object &o) {
 }
 
 jsi::Value TracingRuntime::lockWeakObject(
-    JSI_NO_CONST_3 JSI_CONST_10 jsi::WeakObject &wo) {
+    const jsi::WeakObject &wo) {
   // See comment in TracingRuntime::createWeakObject for why this function isn't
   // traced.
   return RD::lockWeakObject(wo);
@@ -550,12 +542,10 @@ jsi::Array TracingRuntime::createArray(size_t length) {
   return arr;
 }
 
-#if JSI_VERSION >= 9
 jsi::ArrayBuffer TracingRuntime::createArrayBuffer(
     std::shared_ptr<jsi::MutableBuffer> buffer) {
   throw std::logic_error("Cannot create external ArrayBuffers in trace mode.");
 }
-#endif
 
 size_t TracingRuntime::size(const jsi::Array &arr) {
   // Array size inquiries read from the length property, which is
@@ -582,7 +572,7 @@ jsi::Value TracingRuntime::getValueAtIndex(const jsi::Array &arr, size_t i) {
 }
 
 void TracingRuntime::setValueAtIndexImpl(
-    JSI_CONST_10 jsi::Array &arr,
+    const jsi::Array &arr,
     size_t i,
     const jsi::Value &value) {
   trace_.emplace_back<SynthTrace::ArrayWriteRecord>(
@@ -718,10 +708,8 @@ SynthTrace::TraceValue TracingRuntime::toTraceValue(const jsi::Value &value) {
     return SynthTrace::encodeBool(value.getBool());
   } else if (value.isNumber()) {
     return SynthTrace::encodeNumber(value.getNumber());
-#if JSI_VERSION >= 8
   } else if (value.isBigInt()) {
     return trace_.encodeBigInt(getUniqueID(value.getBigInt(*this)));
-#endif
   } else if (value.isString()) {
     return trace_.encodeString(getUniqueID(value.getString(*this)));
   } else if (value.isObject()) {

--- a/API/hermes/TracingRuntime.h
+++ b/API/hermes/TracingRuntime.h
@@ -29,9 +29,7 @@ class TracingRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
       std::unique_ptr<llvh::raw_ostream> traceStream);
 
   virtual SynthTrace::ObjectID getUniqueID(const jsi::Object &o) = 0;
-#if JSI_VERSION >= 8
   virtual SynthTrace::ObjectID getUniqueID(const jsi::BigInt &s) = 0;
-#endif
   virtual SynthTrace::ObjectID getUniqueID(const jsi::String &s) = 0;
   virtual SynthTrace::ObjectID getUniqueID(const jsi::PropNameID &pni) = 0;
   virtual SynthTrace::ObjectID getUniqueID(const jsi::Symbol &sym) = 0;
@@ -45,12 +43,8 @@ class TracingRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
       const std::shared_ptr<const jsi::Buffer> &buffer,
       const std::string &sourceURL) override;
 
-#if JSI_VERSION >= 12
   void queueMicrotask(const jsi::Function &callback) override;
-#endif
-#if JSI_VERSION >= 4
   bool drainMicrotasks(int maxMicrotasksHint = -1) override;
-#endif
 
   jsi::Object createObject() override;
   jsi::Object createObject(std::shared_ptr<jsi::HostObject> ho) override;
@@ -58,11 +52,9 @@ class TracingRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
   // Note that the NativeState methods do not need to be traced since they
   // cannot be observed in JS.
 
-#if JSI_VERSION >= 8
   jsi::BigInt createBigIntFromInt64(int64_t value) override;
   jsi::BigInt createBigIntFromUint64(uint64_t value) override;
   jsi::String bigintToString(const jsi::BigInt &bigint, int radix) override;
-#endif
 
   jsi::String createStringFromAscii(const char *str, size_t length) override;
   jsi::String createStringFromUtf8(const uint8_t *utf8, size_t length) override;
@@ -72,9 +64,7 @@ class TracingRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
   jsi::PropNameID createPropNameIDFromUtf8(const uint8_t *utf8, size_t length)
       override;
   jsi::PropNameID createPropNameIDFromString(const jsi::String &str) override;
-#if JSI_VERSION >= 5
   jsi::PropNameID createPropNameIDFromSymbol(const jsi::Symbol &sym) override;
-#endif
 
   jsi::Value getProperty(const jsi::Object &obj, const jsi::String &name)
       override;
@@ -86,11 +76,11 @@ class TracingRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
       override;
 
   void setPropertyValue(
-      JSI_CONST_10 jsi::Object &obj,
+      const jsi::Object &obj,
       const jsi::String &name,
       const jsi::Value &value) override;
   void setPropertyValue(
-      JSI_CONST_10 jsi::Object &obj,
+      const jsi::Object &obj,
       const jsi::PropNameID &name,
       const jsi::Value &value) override;
 
@@ -99,13 +89,11 @@ class TracingRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
   jsi::WeakObject createWeakObject(const jsi::Object &o) override;
 
   jsi::Value lockWeakObject(
-      JSI_NO_CONST_3 JSI_CONST_10 jsi::WeakObject &wo) override;
+      const jsi::WeakObject &wo) override;
 
   jsi::Array createArray(size_t length) override;
-#if JSI_VERSION >= 9
   jsi::ArrayBuffer createArrayBuffer(
       std::shared_ptr<jsi::MutableBuffer> buffer) override;
-#endif
   size_t size(const jsi::Array &arr) override;
   size_t size(const jsi::ArrayBuffer &buf) override;
 
@@ -114,7 +102,7 @@ class TracingRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
   jsi::Value getValueAtIndex(const jsi::Array &arr, size_t i) override;
 
   void setValueAtIndexImpl(
-      JSI_CONST_10 jsi::Array &arr,
+      const jsi::Array &arr,
       size_t i,
       const jsi::Value &value) override;
 
@@ -204,11 +192,9 @@ class TracingHermesRuntime final : public TracingRuntime {
   SynthTrace::ObjectID getUniqueID(const jsi::Object &o) override {
     return static_cast<SynthTrace::ObjectID>(hermesRuntime().getUniqueID(o));
   }
-#if JSI_VERSION >= 8
   SynthTrace::ObjectID getUniqueID(const jsi::BigInt &b) override {
     return static_cast<SynthTrace::ObjectID>(hermesRuntime().getUniqueID(b));
   }
-#endif
   SynthTrace::ObjectID getUniqueID(const jsi::String &s) override {
     return static_cast<SynthTrace::ObjectID>(hermesRuntime().getUniqueID(s));
   }

--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -509,9 +509,7 @@ class HermesRuntimeImpl final : public HermesRuntime,
       return vm::HermesValue::encodeUntrustedNumberValue(value.getNumber());
     } else if (
         value.isSymbol() ||
-#if JSI_VERSION >= 6
         value.isBigInt() ||
-#endif
         value.isString() || value.isObject()) {
       return phv(value);
     } else {
@@ -531,9 +529,7 @@ class HermesRuntimeImpl final : public HermesRuntime,
           vm::HermesValue::encodeUntrustedNumberValue(value.getNumber()));
     } else if (
         value.isSymbol() ||
-#if JSI_VERSION >= 6
         value.isBigInt() ||
-#endif
         value.isString() || value.isObject()) {
       return vm::Handle<vm::HermesValue>(&phv(value));
     } else {
@@ -552,10 +548,8 @@ class HermesRuntimeImpl final : public HermesRuntime,
       return hv.getDouble();
     } else if (hv.isSymbol()) {
       return add<jsi::Symbol>(hv);
-#if JSI_VERSION >= 6
     } else if (hv.isBigInt()) {
       return add<jsi::BigInt>(hv);
-#endif
     } else if (hv.isString()) {
       return add<jsi::String>(hv);
     } else if (hv.isObject()) {
@@ -581,12 +575,8 @@ class HermesRuntimeImpl final : public HermesRuntime,
   jsi::Value evaluateJavaScript(
       const std::shared_ptr<const jsi::Buffer> &buffer,
       const std::string &sourceURL) override;
-#if JSI_VERSION >= 12
   void queueMicrotask(const jsi::Function &callback) override;
-#endif
-#if JSI_VERSION >= 4
   bool drainMicrotasks(int maxMicrotasksHint = -1) override;
-#endif
   jsi::Object global() override;
 
   std::string description() override;
@@ -594,9 +584,7 @@ class HermesRuntimeImpl final : public HermesRuntime,
   jsi::Instrumentation &instrumentation() override;
 
   PointerValue *cloneSymbol(const Runtime::PointerValue *pv) override;
-#if JSI_VERSION >= 6
   PointerValue *cloneBigInt(const Runtime::PointerValue *pv) override;
-#endif
   PointerValue *cloneString(const Runtime::PointerValue *pv) override;
   PointerValue *cloneObject(const Runtime::PointerValue *pv) override;
   PointerValue *clonePropNameID(const Runtime::PointerValue *pv) override;
@@ -606,44 +594,36 @@ class HermesRuntimeImpl final : public HermesRuntime,
   jsi::PropNameID createPropNameIDFromUtf8(const uint8_t *utf8, size_t length)
       override;
   jsi::PropNameID createPropNameIDFromString(const jsi::String &str) override;
-#if JSI_VERSION >= 5
   jsi::PropNameID createPropNameIDFromSymbol(const jsi::Symbol &sym) override;
-#endif
   std::string utf8(const jsi::PropNameID &) override;
   bool compare(const jsi::PropNameID &, const jsi::PropNameID &) override;
 
   std::string symbolToString(const jsi::Symbol &) override;
 
-#if JSI_VERSION >= 8
   jsi::BigInt createBigIntFromInt64(int64_t) override;
   jsi::BigInt createBigIntFromUint64(uint64_t) override;
   bool bigintIsInt64(const jsi::BigInt &) override;
   bool bigintIsUint64(const jsi::BigInt &) override;
   uint64_t truncate(const jsi::BigInt &) override;
   jsi::String bigintToString(const jsi::BigInt &, int) override;
-#endif
 
   jsi::String createStringFromAscii(const char *str, size_t length) override;
   jsi::String createStringFromUtf8(const uint8_t *utf8, size_t length) override;
   std::string utf8(const jsi::String &) override;
 
-#if JSI_VERSION >= 2
   jsi::Value createValueFromJsonUtf8(const uint8_t *json, size_t length)
       override;
-#endif
 
   jsi::Object createObject() override;
   jsi::Object createObject(std::shared_ptr<jsi::HostObject> ho) override;
   std::shared_ptr<jsi::HostObject> getHostObject(const jsi::Object &) override;
   jsi::HostFunctionType &getHostFunction(const jsi::Function &) override;
 
-#if JSI_VERSION >= 7
   bool hasNativeState(const jsi::Object &) override;
   std::shared_ptr<jsi::NativeState> getNativeState(
       const jsi::Object &) override;
   void setNativeState(const jsi::Object &, std::shared_ptr<jsi::NativeState>)
       override;
-#endif
   void setExternalMemoryPressure(const jsi::Object &, size_t) override;
 
   jsi::Value getProperty(const jsi::Object &, const jsi::PropNameID &name)
@@ -652,11 +632,11 @@ class HermesRuntimeImpl final : public HermesRuntime,
   bool hasProperty(const jsi::Object &, const jsi::PropNameID &name) override;
   bool hasProperty(const jsi::Object &, const jsi::String &name) override;
   void setPropertyValue(
-      JSI_CONST_10 jsi::Object &,
+      const jsi::Object &,
       const jsi::PropNameID &name,
       const jsi::Value &value) override;
   void setPropertyValue(
-      JSI_CONST_10 jsi::Object &,
+      const jsi::Object &,
       const jsi::String &name,
       const jsi::Value &value) override;
   bool isArray(const jsi::Object &) const override;
@@ -668,19 +648,17 @@ class HermesRuntimeImpl final : public HermesRuntime,
 
   jsi::WeakObject createWeakObject(const jsi::Object &) override;
   jsi::Value lockWeakObject(
-      JSI_NO_CONST_3 JSI_CONST_10 jsi::WeakObject &wo) override;
+     const jsi::WeakObject &wo) override;
 
   jsi::Array createArray(size_t length) override;
-#if JSI_VERSION >= 9
   jsi::ArrayBuffer createArrayBuffer(
       std::shared_ptr<jsi::MutableBuffer> buffer) override;
-#endif
   size_t size(const jsi::Array &) override;
   size_t size(const jsi::ArrayBuffer &) override;
   uint8_t *data(const jsi::ArrayBuffer &) override;
   jsi::Value getValueAtIndex(const jsi::Array &, size_t i) override;
   void setValueAtIndexImpl(
-      JSI_CONST_10 jsi::Array &,
+      const jsi::Array &,
       size_t i,
       const jsi::Value &value) override;
 
@@ -699,9 +677,7 @@ class HermesRuntimeImpl final : public HermesRuntime,
       size_t count) override;
 
   bool strictEquals(const jsi::Symbol &a, const jsi::Symbol &b) const override;
-#if JSI_VERSION >= 6
   bool strictEquals(const jsi::BigInt &a, const jsi::BigInt &b) const override;
-#endif
   bool strictEquals(const jsi::String &a, const jsi::String &b) const override;
   bool strictEquals(const jsi::Object &a, const jsi::Object &b) const override;
 
@@ -1249,12 +1225,10 @@ uint64_t HermesRuntime::getUniqueID(const jsi::Object &o) const {
       static_cast<vm::GCCell *>(impl(this)->phv(o).getObject()));
 }
 
-#if JSI_VERSION >= 8
 uint64_t HermesRuntime::getUniqueID(const jsi::BigInt &s) const {
   return impl(this)->runtime_.getHeap().getObjectID(
       static_cast<vm::GCCell *>(impl(this)->phv(s).getBigInt()));
 }
-#endif
 
 uint64_t HermesRuntime::getUniqueID(const jsi::String &s) const {
   return impl(this)->runtime_.getHeap().getObjectID(
@@ -1540,7 +1514,6 @@ jsi::Value HermesRuntimeImpl::evaluateJavaScript(
   return evaluateJavaScriptWithSourceMap(buffer, nullptr, sourceURL);
 }
 
-#if JSI_VERSION >= 12
 void HermesRuntimeImpl::queueMicrotask(const jsi::Function &callback) {
   if (LLVM_UNLIKELY(!runtime_.hasMicrotaskQueue())) {
     throw jsi::JSINativeException(
@@ -1551,9 +1524,7 @@ void HermesRuntimeImpl::queueMicrotask(const jsi::Function &callback) {
       vm::Handle<vm::Callable>::vmcast(&phv(callback));
   runtime_.enqueueJob(handle.get());
 }
-#endif
 
-#if JSI_VERSION >= 4
 bool HermesRuntimeImpl::drainMicrotasks(int maxMicrotasksHint) {
   if (runtime_.hasMicrotaskQueue()) {
     checkStatus(runtime_.drainJobs());
@@ -1563,7 +1534,6 @@ bool HermesRuntimeImpl::drainMicrotasks(int maxMicrotasksHint) {
   runtime_.clearKeptObjects();
   return true;
 }
-#endif
 
 jsi::Object HermesRuntimeImpl::global() {
   return add<jsi::Object>(runtime_.getGlobal().getHermesValue());
@@ -1595,12 +1565,10 @@ jsi::Runtime::PointerValue *HermesRuntimeImpl::cloneSymbol(
   return clone(pv);
 }
 
-#if JSI_VERSION >= 6
 jsi::Runtime::PointerValue *HermesRuntimeImpl::cloneBigInt(
     const Runtime::PointerValue *pv) {
   return clone(pv);
 }
-#endif
 
 jsi::Runtime::PointerValue *HermesRuntimeImpl::cloneString(
     const Runtime::PointerValue *pv) {
@@ -1657,12 +1625,10 @@ jsi::PropNameID HermesRuntimeImpl::createPropNameIDFromString(
   return add<jsi::PropNameID>(cr->getHermesValue());
 }
 
-#if JSI_VERSION >= 5
 jsi::PropNameID HermesRuntimeImpl::createPropNameIDFromSymbol(
     const jsi::Symbol &sym) {
   return add<jsi::PropNameID>(phv(sym));
 }
-#endif
 
 std::string HermesRuntimeImpl::utf8(const jsi::PropNameID &sym) {
   vm::GCScope gcScope(runtime_);
@@ -1710,7 +1676,6 @@ std::string HermesRuntimeImpl::symbolToString(const jsi::Symbol &sym) {
       vm::StringPrimitive::createStringView(runtime_, *res));
 }
 
-#if JSI_VERSION >= 8
 jsi::BigInt HermesRuntimeImpl::createBigIntFromInt64(int64_t value) {
   vm::GCScope gcScope(runtime_);
   vm::CallResult<vm::HermesValue> res =
@@ -1761,7 +1726,6 @@ jsi::String HermesRuntimeImpl::bigintToString(
   checkStatus(toStringRes.getStatus());
   return add<jsi::String>(*toStringRes);
 }
-#endif
 
 jsi::String HermesRuntimeImpl::createStringFromAscii(
     const char *str,
@@ -1789,7 +1753,6 @@ std::string HermesRuntimeImpl::utf8(const jsi::String &str) {
       vm::StringPrimitive::createStringView(runtime_, stringHandle(str)));
 }
 
-#if JSI_VERSION >= 2
 jsi::Value HermesRuntimeImpl::createValueFromJsonUtf8(
     const uint8_t *json,
     size_t length) {
@@ -1800,7 +1763,6 @@ jsi::Value HermesRuntimeImpl::createValueFromJsonUtf8(
   checkStatus(res.getStatus());
   return valueFromHermesValue(*res);
 }
-#endif
 
 jsi::Object HermesRuntimeImpl::createObject() {
   vm::GCScope gcScope(runtime_);
@@ -1824,7 +1786,6 @@ std::shared_ptr<jsi::HostObject> HermesRuntimeImpl::getHostObject(
   return static_cast<const JsiProxy *>(proxy)->ho_;
 }
 
-#if JSI_VERSION >= 7
 bool HermesRuntimeImpl::hasNativeState(const jsi::Object &obj) {
   vm::GCScope gcScope(runtime_);
   auto h = handle(obj);
@@ -1895,7 +1856,6 @@ std::shared_ptr<jsi::NativeState> HermesRuntimeImpl::getNativeState(
   return std::shared_ptr(
       *reinterpret_cast<std::shared_ptr<jsi::NativeState> *>(ns->context()));
 }
-#endif
 
 void HermesRuntimeImpl::setExternalMemoryPressure(
     const jsi::Object &obj,
@@ -2010,7 +1970,7 @@ bool HermesRuntimeImpl::hasProperty(
 }
 
 void HermesRuntimeImpl::setPropertyValue(
-    JSI_CONST_10 jsi::Object &obj,
+    const jsi::Object &obj,
     const jsi::String &name,
     const jsi::Value &value) {
   vm::GCScope gcScope(runtime_);
@@ -2025,7 +1985,7 @@ void HermesRuntimeImpl::setPropertyValue(
 }
 
 void HermesRuntimeImpl::setPropertyValue(
-    JSI_CONST_10 jsi::Object &obj,
+    const jsi::Object &obj,
     const jsi::PropNameID &name,
     const jsi::Value &value) {
   vm::GCScope gcScope(runtime_);
@@ -2095,7 +2055,7 @@ jsi::WeakObject HermesRuntimeImpl::createWeakObject(const jsi::Object &obj) {
 }
 
 jsi::Value HermesRuntimeImpl::lockWeakObject(
-    JSI_NO_CONST_3 JSI_CONST_10 jsi::WeakObject &wo) {
+    const jsi::WeakObject &wo) {
   const vm::WeakRoot<vm::JSObject> &wr = weakRoot(wo);
 
   if (const auto ptr = wr.get(runtime_, runtime_.getHeap()))
@@ -2111,7 +2071,6 @@ jsi::Array HermesRuntimeImpl::createArray(size_t length) {
   return add<jsi::Array>(result->getHermesValue());
 }
 
-#if JSI_VERSION >= 9
 jsi::ArrayBuffer HermesRuntimeImpl::createArrayBuffer(
     std::shared_ptr<jsi::MutableBuffer> buffer) {
   vm::GCScope gcScope(runtime_);
@@ -2129,7 +2088,6 @@ jsi::ArrayBuffer HermesRuntimeImpl::createArrayBuffer(
   checkStatus(res);
   return add<jsi::ArrayBuffer>(buf.getHermesValue());
 }
-#endif
 
 size_t HermesRuntimeImpl::size(const jsi::Array &arr) {
   return vm::JSArray::getLength(*arrayHandle(arr), runtime_);
@@ -2166,7 +2124,7 @@ jsi::Value HermesRuntimeImpl::getValueAtIndex(const jsi::Array &arr, size_t i) {
 }
 
 void HermesRuntimeImpl::setValueAtIndexImpl(
-    JSI_CONST_10 jsi::Array &arr,
+    const jsi::Array &arr,
     size_t i,
     const jsi::Value &value) {
   vm::GCScope gcScope(runtime_);
@@ -2327,12 +2285,10 @@ bool HermesRuntimeImpl::strictEquals(const jsi::Symbol &a, const jsi::Symbol &b)
   return phv(a).getSymbol() == phv(b).getSymbol();
 }
 
-#if JSI_VERSION >= 6
 bool HermesRuntimeImpl::strictEquals(const jsi::BigInt &a, const jsi::BigInt &b)
     const {
   return phv(a).getBigInt()->compare(phv(b).getBigInt()) == 0;
 }
-#endif
 
 bool HermesRuntimeImpl::strictEquals(const jsi::String &a, const jsi::String &b)
     const {

--- a/API/hermes/hermes.h
+++ b/API/hermes/hermes.h
@@ -120,9 +120,7 @@ class HERMES_EXPORT HermesRuntime : public jsi::Runtime {
   /// static throughout that object's (or string's, or PropNameID's)
   /// lifetime.
   uint64_t getUniqueID(const jsi::Object &o) const;
-#if JSI_VERSION >= 8
   uint64_t getUniqueID(const jsi::BigInt &s) const;
-#endif
   uint64_t getUniqueID(const jsi::String &s) const;
   uint64_t getUniqueID(const jsi::PropNameID &pni) const;
   uint64_t getUniqueID(const jsi::Symbol &sym) const;

--- a/API/hermes_node_api_jsi/NodeApiJsiRuntime.cpp
+++ b/API/hermes_node_api_jsi/NodeApiJsiRuntime.cpp
@@ -14,29 +14,6 @@
 #include <unordered_map>
 #include <unordered_set>
 
-// JSI version defines set of features available in the API.
-// Each significant API change must be under a new version.
-// These macros must be defined in jsi.h, but define them here too
-// in case if this code is used with unmodified jsi.h.
-#ifndef JSI_VERSION
-#define JSI_VERSION 10
-#endif
-
-#ifndef JSI_NO_CONST_3
-#if JSI_VERSION >= 3
-#define JSI_NO_CONST_3
-#else
-#define JSI_NO_CONST_3 const
-#endif
-#endif
-
-#ifndef JSI_CONST_10
-#if JSI_VERSION >= 10
-#define JSI_CONST_10 const
-#else
-#define JSI_CONST_10
-#endif
-#endif
 
 using namespace facebook;
 using namespace std::string_view_literals;
@@ -197,21 +174,15 @@ class NodeApiJsiRuntime : public jsi::Runtime {
       std::string sourceURL) override;
   jsi::Value evaluatePreparedJavaScript(
       const std::shared_ptr<const jsi::PreparedJavaScript> &js) override;
-#if JSI_VERSION >= 12
   void queueMicrotask(const jsi::Function &callback) override;
-#endif
-#if JSI_VERSION >= 4
   bool drainMicrotasks(int maxMicrotasksHint = -1) override;
-#endif
   jsi::Object global() override;
   std::string description() override;
   bool isInspectable() override;
 
  protected:
   PointerValue *cloneSymbol(const PointerValue *pointerValue) override;
-#if JSI_VERSION >= 6
   PointerValue *cloneBigInt(const PointerValue *pointerValue) override;
-#endif
   PointerValue *cloneString(const PointerValue *pointerValue) override;
   PointerValue *cloneObject(const PointerValue *pointerValue) override;
   PointerValue *clonePropNameID(const PointerValue *pointerValue) override;
@@ -221,22 +192,18 @@ class NodeApiJsiRuntime : public jsi::Runtime {
   jsi::PropNameID createPropNameIDFromUtf8(const uint8_t *utf8, size_t length)
       override;
   jsi::PropNameID createPropNameIDFromString(const jsi::String &str) override;
-#if JSI_VERSION >= 5
   jsi::PropNameID createPropNameIDFromSymbol(const jsi::Symbol &sym) override;
-#endif
   std::string utf8(const jsi::PropNameID &id) override;
   bool compare(const jsi::PropNameID &lhs, const jsi::PropNameID &rhs) override;
 
   std::string symbolToString(const jsi::Symbol &s) override;
 
-#if JSI_VERSION >= 8
   jsi::BigInt createBigIntFromInt64(int64_t value) override;
   jsi::BigInt createBigIntFromUint64(uint64_t value) override;
   bool bigintIsInt64(const jsi::BigInt &value) override;
   bool bigintIsUint64(const jsi::BigInt &value) override;
   uint64_t truncate(const jsi::BigInt &value) override;
   jsi::String bigintToString(const jsi::BigInt &value, int radix) override;
-#endif
 
   jsi::String createStringFromAscii(const char *str, size_t length) override;
   jsi::String createStringFromUtf8(const uint8_t *utf8, size_t length) override;
@@ -247,14 +214,12 @@ class NodeApiJsiRuntime : public jsi::Runtime {
   std::shared_ptr<jsi::HostObject> getHostObject(const jsi::Object &) override;
   jsi::HostFunctionType &getHostFunction(const jsi::Function &) override;
 
-#if JSI_VERSION >= 7
   bool hasNativeState(const jsi::Object &value) override;
   std::shared_ptr<jsi::NativeState> getNativeState(
       const jsi::Object &value) override;
   void setNativeState(
       const jsi::Object &value,
       std::shared_ptr<jsi::NativeState> state) override;
-#endif
 
   jsi::Value getProperty(const jsi::Object &obj, const jsi::PropNameID &name)
       override;
@@ -264,11 +229,11 @@ class NodeApiJsiRuntime : public jsi::Runtime {
       override;
   bool hasProperty(const jsi::Object &obj, const jsi::String &name) override;
   void setPropertyValue(
-      JSI_CONST_10 jsi::Object &obj,
+      const jsi::Object &obj,
       const jsi::PropNameID &name,
       const jsi::Value &value) override;
   void setPropertyValue(
-      JSI_CONST_10 jsi::Object &obj,
+      const jsi::Object &obj,
       const jsi::String &name,
       const jsi::Value &value) override;
 
@@ -281,19 +246,17 @@ class NodeApiJsiRuntime : public jsi::Runtime {
 
   jsi::WeakObject createWeakObject(const jsi::Object &obj) override;
   jsi::Value lockWeakObject(
-      JSI_NO_CONST_3 JSI_CONST_10 jsi::WeakObject &weakObj) override;
+      const jsi::WeakObject &weakObj) override;
 
   jsi::Array createArray(size_t length) override;
-#if JSI_VERSION >= 9
   jsi::ArrayBuffer createArrayBuffer(
       std::shared_ptr<jsi::MutableBuffer> buffer);
-#endif
   size_t size(const jsi::Array &arr) override;
   size_t size(const jsi::ArrayBuffer &arrBuf) override;
   uint8_t *data(const jsi::ArrayBuffer &arrBuff) override;
   jsi::Value getValueAtIndex(const jsi::Array &arr, size_t index) override;
   void setValueAtIndexImpl(
-      JSI_CONST_10 jsi::Array &arr,
+      const jsi::Array &arr,
       size_t index,
       const jsi::Value &value) override;
 
@@ -315,18 +278,14 @@ class NodeApiJsiRuntime : public jsi::Runtime {
   void popScope(ScopeState *) override;
 
   bool strictEquals(const jsi::Symbol &a, const jsi::Symbol &b) const override;
-#if JSI_VERSION >= 6
   bool strictEquals(const jsi::BigInt &a, const jsi::BigInt &b) const override;
-#endif
   bool strictEquals(const jsi::String &a, const jsi::String &b) const override;
   bool strictEquals(const jsi::Object &a, const jsi::Object &b) const override;
 
   bool instanceOf(const jsi::Object &obj, const jsi::Function &func) override;
 
-#if JSI_VERSION >= 11
   void setExternalMemoryPressure(const jsi::Object &obj, size_t amount)
       override;
-#endif
 
  private:
   // RAII class to open and close the environment scope.
@@ -972,12 +931,10 @@ class NodeApiJsiRuntime : public jsi::Runtime {
       typename T,
       std::enable_if_t<std::is_same_v<jsi::Symbol, T>, int> = 0>
   T makeJsiPointer(napi_value value) const;
-#if JSI_VERSION >= 6
   template <
       typename T,
       std::enable_if_t<std::is_same_v<jsi::BigInt, T>, int> = 0>
   T makeJsiPointer(napi_value value) const;
-#endif
   template <
       typename TTo,
       typename TFrom,
@@ -1236,21 +1193,17 @@ jsi::Value NodeApiJsiRuntime::evaluatePreparedJavaScript(
   return toJsiValue(result);
 }
 
-#if JSI_VERSION >= 12
 void NodeApiJsiRuntime::queueMicrotask(const jsi::Function &callback) {
   NodeApiScope scope{*this};
   napi_value callbackValue = getNodeApiValue(callback);
   CHECK_NAPI(jsrApi_->jsr_queue_microtask(env_, callbackValue));
 }
-#endif
 
-#if JSI_VERSION >= 4
 bool NodeApiJsiRuntime::drainMicrotasks(int maxMicrotasksHint) {
   bool result{};
   CHECK_NAPI(jsrApi_->jsr_drain_microtasks(env_, maxMicrotasksHint, &result));
   return result;
 }
-#endif
 
 jsi::Object NodeApiJsiRuntime::global() {
   return make<jsi::Object>(cachedValue_.Global->clone(*this));
@@ -1273,12 +1226,10 @@ jsi::Runtime::PointerValue *NodeApiJsiRuntime::cloneSymbol(
   return cloneNodeApiPointerValue(pointerValue);
 }
 
-#if JSI_VERSION >= 6
 jsi::Runtime::PointerValue *NodeApiJsiRuntime::cloneBigInt(
     const jsi::Runtime::PointerValue *pointerValue) {
   return cloneNodeApiPointerValue(pointerValue);
 }
-#endif
 
 jsi::Runtime::PointerValue *NodeApiJsiRuntime::cloneString(
     const jsi::Runtime::PointerValue *pointerValue) {
@@ -1394,13 +1345,11 @@ jsi::PropNameID NodeApiJsiRuntime::createPropNameIDFromString(
   return result;
 }
 
-#if JSI_VERSION >= 5
 jsi::PropNameID NodeApiJsiRuntime::createPropNameIDFromSymbol(
     const jsi::Symbol &sym) {
   // TODO: Should we ensure uniqueness of symbols?
   return cloneAs<jsi::PropNameID>(sym);
 }
-#endif
 
 std::string NodeApiJsiRuntime::utf8(const jsi::PropNameID &id) {
   NodeApiScope scope{*this};
@@ -1420,7 +1369,6 @@ std::string NodeApiJsiRuntime::symbolToString(const jsi::Symbol &sym) {
   return symbolToStdString(getNodeApiValue(sym));
 }
 
-#if JSI_VERSION >= 8
 jsi::BigInt NodeApiJsiRuntime::createBigIntFromInt64(int64_t val) {
   NodeApiScope scope{*this};
   napi_value bigint{};
@@ -1594,7 +1542,6 @@ jsi::String NodeApiJsiRuntime::bigintToString(
   std::reverse(digits.begin(), digits.end());
   return createStringFromAscii(digits.data(), digits.size());
 }
-#endif
 
 jsi::String NodeApiJsiRuntime::createStringFromAscii(
     const char *str,
@@ -1668,7 +1615,6 @@ jsi::HostFunctionType &NodeApiJsiRuntime::getHostFunction(
   }
 }
 
-#if JSI_VERSION >= 7
 bool NodeApiJsiRuntime::hasNativeState(const jsi::Object &obj) {
   NodeApiScope scope{*this};
   void *nativeState{};
@@ -1716,7 +1662,6 @@ void NodeApiJsiRuntime::setNativeState(
         nullptr));
   }
 }
-#endif
 
 jsi::Value NodeApiJsiRuntime::getProperty(
     const jsi::Object &obj,
@@ -1747,7 +1692,7 @@ bool NodeApiJsiRuntime::hasProperty(
 }
 
 void NodeApiJsiRuntime::setPropertyValue(
-    JSI_CONST_10 jsi::Object &obj,
+    const jsi::Object &obj,
     const jsi::PropNameID &name,
     const jsi::Value &value) {
   NodeApiScope scope{*this};
@@ -1756,7 +1701,7 @@ void NodeApiJsiRuntime::setPropertyValue(
 }
 
 void NodeApiJsiRuntime::setPropertyValue(
-    JSI_CONST_10 jsi::Object &obj,
+    const jsi::Object &obj,
     const jsi::String &name,
     const jsi::Value &value) {
   NodeApiScope scope{*this};
@@ -1826,7 +1771,7 @@ jsi::WeakObject NodeApiJsiRuntime::createWeakObject(const jsi::Object &obj) {
 }
 
 jsi::Value NodeApiJsiRuntime::lockWeakObject(
-    JSI_NO_CONST_3 JSI_CONST_10 jsi::WeakObject &weakObject) {
+    const jsi::WeakObject &weakObject) {
   NodeApiScope scope{*this};
   napi_value value = getNodeApiValue(weakObject);
   if (value) {
@@ -1841,7 +1786,6 @@ jsi::Array NodeApiJsiRuntime::createArray(size_t length) {
   return makeJsiPointer<jsi::Object>(createNodeApiArray(length)).asArray(*this);
 }
 
-#if JSI_VERSION >= 9
 jsi::ArrayBuffer NodeApiJsiRuntime::createArrayBuffer(
     std::shared_ptr<jsi::MutableBuffer> buffer) {
   NodeApiScope scope{*this};
@@ -1861,7 +1805,6 @@ jsi::ArrayBuffer NodeApiJsiRuntime::createArrayBuffer(
       &result));
   return makeJsiPointer<jsi::Object>(result).getArrayBuffer(*this);
 }
-#endif
 
 size_t NodeApiJsiRuntime::size(const jsi::Array &arr) {
   NodeApiScope scope{*this};
@@ -1895,7 +1838,7 @@ jsi::Value NodeApiJsiRuntime::getValueAtIndex(
 }
 
 void NodeApiJsiRuntime::setValueAtIndexImpl(
-    JSI_CONST_10 jsi::Array &arr,
+    const jsi::Array &arr,
     size_t index,
     const jsi::Value &value) {
   NodeApiScope scope{*this};
@@ -1969,13 +1912,11 @@ bool NodeApiJsiRuntime::strictEquals(const jsi::Symbol &a, const jsi::Symbol &b)
   return strictEquals(getNodeApiValue(a), getNodeApiValue(b));
 }
 
-#if JSI_VERSION >= 6
 bool NodeApiJsiRuntime::strictEquals(const jsi::BigInt &a, const jsi::BigInt &b)
     const {
   NodeApiScope scope{*this};
   return strictEquals(getNodeApiValue(a), getNodeApiValue(b));
 }
-#endif
 
 bool NodeApiJsiRuntime::strictEquals(const jsi::String &a, const jsi::String &b)
     const {
@@ -1996,13 +1937,11 @@ bool NodeApiJsiRuntime::instanceOf(
   return instanceOf(getNodeApiValue(obj), getNodeApiValue(func));
 }
 
-#if JSI_VERSION >= 11
 void NodeApiJsiRuntime::setExternalMemoryPressure(
     const jsi::Object & /*obj*/,
     size_t /*amount*/) {
   // TODO: implement
 }
-#endif
 
 //=====================================================================================================================
 // NodeApiJsiRuntime::NodeApiScope implementation
@@ -2338,11 +2277,9 @@ NodeApiJsiRuntime::JsiValueView::operator const jsi::Value &() const noexcept {
     case napi_valuetype::napi_external:
       return make<jsi::Object>(new (store) NodeApiStackOnlyPointerValue(
           value, NodeApiPointerValueKind::Object));
-#if JSI_VERSION >= 8
     case napi_valuetype::napi_bigint:
       return make<jsi::BigInt>(new (store) NodeApiStackOnlyPointerValue(
           value, NodeApiPointerValueKind::BigInt));
-#endif
     default:
       throw jsi::JSINativeException("Unexpected value type");
   }
@@ -3104,14 +3041,12 @@ napi_value NodeApiJsiRuntime::hostObjectOwnKeysTrap(span<napi_value> args) {
       if (keyType == napi_string) {
         addPropNameId(
             createPropNameIDFromString(makeJsiPointer<jsi::String>(key)));
-#if JSI_VERSION >= 8
       } else if (keyType == napi_symbol) {
         if (strictEquals(key, getNodeApiValue(propertyId_.hostObjectSymbol))) {
           continue;
         }
         addPropNameId(
             createPropNameIDFromSymbol(makeJsiPointer<jsi::Symbol>(key)));
-#endif
       } else {
         throwNativeException("Unexpected key type");
       }
@@ -3232,10 +3167,8 @@ jsi::Value NodeApiJsiRuntime::toJsiValue(napi_value value) const {
     case napi_valuetype::napi_function:
     case napi_valuetype::napi_external:
       return jsi::Value{makeJsiPointer<jsi::Object>(value)};
-#if JSI_VERSION >= 6
     case napi_valuetype::napi_bigint:
       return jsi::Value{makeJsiPointer<jsi::BigInt>(value)};
-#endif
     default:
       throw jsi::JSINativeException("Unexpected value type");
   }
@@ -3259,11 +3192,9 @@ napi_value NodeApiJsiRuntime::getNodeApiValue(const jsi::Value &value) const {
   } else if (value.isObject()) {
     return getNodeApiValue(
         value.getObject(*const_cast<NodeApiJsiRuntime *>(this)));
-#if JSI_VERSION >= 8
   } else if (value.isBigInt()) {
     return getNodeApiValue(
         value.getBigInt(*const_cast<NodeApiJsiRuntime *>(this)));
-#endif
   } else {
     throw jsi::JSINativeException("Unexpected jsi::Value type");
   }
@@ -3349,7 +3280,6 @@ T NodeApiJsiRuntime::makeJsiPointer(napi_value value) const {
                      .release());
 }
 
-#if JSI_VERSION >= 6
 template <typename T, std::enable_if_t<std::is_same_v<jsi::BigInt, T>, int>>
 T NodeApiJsiRuntime::makeJsiPointer(napi_value value) const {
   return make<T>(NodeApiRefCountedPointerValue::make(
@@ -3358,7 +3288,6 @@ T NodeApiJsiRuntime::makeJsiPointer(napi_value value) const {
                      NodeApiPointerValueKind::BigInt)
                      .release());
 }
-#endif
 
 template <
     typename TTo,

--- a/API/jsi/jsi/JSIDynamic.cpp
+++ b/API/jsi/jsi/JSIDynamic.cpp
@@ -139,10 +139,8 @@ void dynamicFromValueShallow(
       output = folly::dynamic::object();
     }
     stack.emplace_back(&output, std::move(obj));
-#if JSI_VERSION >= 8
   } else if (value.isBigInt()) {
     throw JSError(runtime, "JS BigInts are not convertible to dynamic");
-#endif
   } else if (value.isSymbol()) {
     throw JSError(runtime, "JS Symbols are not convertible to dynamic");
   } else {

--- a/API/jsi/jsi/decorator.h
+++ b/API/jsi/jsi/decorator.h
@@ -126,16 +126,12 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
       const std::shared_ptr<const PreparedJavaScript>& js) override {
     return plain().evaluatePreparedJavaScript(js);
   }
-#if JSI_VERSION >= 12
   void queueMicrotask(const jsi::Function& callback) override {
     return plain().queueMicrotask(callback);
   }
-#endif
-#if JSI_VERSION >= 4
   bool drainMicrotasks(int maxMicrotasksHint) override {
     return plain().drainMicrotasks(maxMicrotasksHint);
   }
-#endif
   Object global() override {
     return plain().global();
   }
@@ -161,11 +157,9 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   Runtime::PointerValue* cloneSymbol(const Runtime::PointerValue* pv) override {
     return plain_.cloneSymbol(pv);
   };
-#if JSI_VERSION >= 6
   Runtime::PointerValue* cloneBigInt(const Runtime::PointerValue* pv) override {
     return plain_.cloneBigInt(pv);
   };
-#endif
   Runtime::PointerValue* cloneString(const Runtime::PointerValue* pv) override {
     return plain_.cloneString(pv);
   };
@@ -188,11 +182,9 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   PropNameID createPropNameIDFromString(const String& str) override {
     return plain_.createPropNameIDFromString(str);
   };
-#if JSI_VERSION >= 5
   PropNameID createPropNameIDFromSymbol(const Symbol& sym) override {
     return plain_.createPropNameIDFromSymbol(sym);
   };
-#endif
   std::string utf8(const PropNameID& id) override {
     return plain_.utf8(id);
   };
@@ -204,7 +196,6 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
     return plain_.symbolToString(sym);
   }
 
-#if JSI_VERSION >= 8
   BigInt createBigIntFromInt64(int64_t value) override {
     return plain_.createBigIntFromInt64(value);
   }
@@ -223,7 +214,6 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   String bigintToString(const BigInt& bigint, int radix) override {
     return plain_.bigintToString(bigint, radix);
   }
-#endif
 
   String createStringFromAscii(const char* str, size_t length) override {
     return plain_.createStringFromAscii(str, length);
@@ -254,7 +244,6 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
     return dhf.target<DecoratedHostFunction>()->plainHF_;
   };
 
-#if JSI_VERSION >= 7
   bool hasNativeState(const Object& o) override {
     return plain_.hasNativeState(o);
   }
@@ -265,13 +254,10 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
       override {
     plain_.setNativeState(o, state);
   }
-#endif
 
-#if JSI_VERSION >= 11
   void setExternalMemoryPressure(const Object& obj, size_t amt) override {
     plain_.setExternalMemoryPressure(obj, amt);
   }
-#endif
 
   Value getProperty(const Object& o, const PropNameID& name) override {
     return plain_.getProperty(o, name);
@@ -286,13 +272,13 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
     return plain_.hasProperty(o, name);
   };
   void setPropertyValue(
-      JSI_CONST_10 Object& o,
+      const Object& o,
       const PropNameID& name,
       const Value& value) override {
     plain_.setPropertyValue(o, name, value);
   };
   void setPropertyValue(
-      JSI_CONST_10 Object& o,
+      const Object& o,
       const String& name,
       const Value& value) override {
     plain_.setPropertyValue(o, name, value);
@@ -320,19 +306,17 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   WeakObject createWeakObject(const Object& o) override {
     return plain_.createWeakObject(o);
   };
-  Value lockWeakObject(JSI_NO_CONST_3 JSI_CONST_10 WeakObject& wo) override {
+  Value lockWeakObject(const WeakObject& wo) override {
     return plain_.lockWeakObject(wo);
   };
 
   Array createArray(size_t length) override {
     return plain_.createArray(length);
   };
-#if JSI_VERSION >= 9
   ArrayBuffer createArrayBuffer(
       std::shared_ptr<MutableBuffer> buffer) override {
     return plain_.createArrayBuffer(std::move(buffer));
   };
-#endif
   size_t size(const Array& a) override {
     return plain_.size(a);
   };
@@ -345,7 +329,7 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   Value getValueAtIndex(const Array& a, size_t i) override {
     return plain_.getValueAtIndex(a, i);
   };
-  void setValueAtIndexImpl(JSI_CONST_10 Array& a, size_t i, const Value& value)
+  void setValueAtIndexImpl(const Array& a, size_t i, const Value& value)
       override {
     plain_.setValueAtIndexImpl(a, i, value);
   };
@@ -380,11 +364,9 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   bool strictEquals(const Symbol& a, const Symbol& b) const override {
     return plain_.strictEquals(a, b);
   };
-#if JSI_VERSION >= 6
   bool strictEquals(const BigInt& a, const BigInt& b) const override {
     return plain_.strictEquals(a, b);
   };
-#endif
   bool strictEquals(const String& a, const String& b) const override {
     return plain_.strictEquals(a, b);
   };
@@ -567,18 +549,14 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     return RD::evaluatePreparedJavaScript(js);
   }
-#if JSI_VERSION >= 12
   void queueMicrotask(const Function& callback) override {
     Around around{with_};
     RD::queueMicrotask(callback);
   }
-#endif
-#if JSI_VERSION >= 4
   bool drainMicrotasks(int maxMicrotasksHint) override {
     Around around{with_};
     return RD::drainMicrotasks(maxMicrotasksHint);
   }
-#endif
   Object global() override {
     Around around{with_};
     return RD::global();
@@ -695,14 +673,14 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     return RD::hasProperty(o, name);
   };
   void setPropertyValue(
-      JSI_CONST_10 Object& o,
+      const Object& o,
       const PropNameID& name,
       const Value& value) override {
     Around around{with_};
     RD::setPropertyValue(o, name, value);
   };
   void setPropertyValue(
-      JSI_CONST_10 Object& o,
+      const Object& o,
       const String& name,
       const Value& value) override {
     Around around{with_};
@@ -738,7 +716,7 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     return RD::createWeakObject(o);
   };
-  Value lockWeakObject(JSI_NO_CONST_3 JSI_CONST_10 WeakObject& wo) override {
+  Value lockWeakObject(const WeakObject& wo) override {
     Around around{with_};
     return RD::lockWeakObject(wo);
   };
@@ -747,12 +725,10 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     return RD::createArray(length);
   };
-#if JSI_VERSION >= 9
   ArrayBuffer createArrayBuffer(
       std::shared_ptr<MutableBuffer> buffer) override {
     return RD::createArrayBuffer(std::move(buffer));
   };
-#endif
   size_t size(const Array& a) override {
     Around around{with_};
     return RD::size(a);
@@ -769,7 +745,7 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     return RD::getValueAtIndex(a, i);
   };
-  void setValueAtIndexImpl(JSI_CONST_10 Array& a, size_t i, const Value& value)
+  void setValueAtIndexImpl(const Array& a, size_t i, const Value& value)
       override {
     Around around{with_};
     RD::setValueAtIndexImpl(a, i, value);

--- a/API/jsi/jsi/jsi-inl.h
+++ b/API/jsi/jsi/jsi-inl.h
@@ -70,11 +70,9 @@ inline T Runtime::make(Runtime::PointerValue* pv) {
   return T(pv);
 }
 
-#if JSI_VERSION >= 3
 inline Runtime::PointerValue* Runtime::getPointerValue(jsi::Pointer& pointer) {
   return pointer.ptr_;
 }
-#endif
 
 inline const Runtime::PointerValue* Runtime::getPointerValue(
     const jsi::Pointer& pointer) {
@@ -114,21 +112,21 @@ inline bool Object::hasProperty(Runtime& runtime, const PropNameID& name)
 
 template <typename T>
 void Object::setProperty(Runtime& runtime, const char* name, T&& value)
-    JSI_CONST_10 {
+    const {
   setProperty(
       runtime, String::createFromAscii(runtime, name), std::forward<T>(value));
 }
 
 template <typename T>
 void Object::setProperty(Runtime& runtime, const String& name, T&& value)
-    JSI_CONST_10 {
+    const {
   setPropertyValue(
       runtime, name, detail::toValue(runtime, std::forward<T>(value)));
 }
 
 template <typename T>
 void Object::setProperty(Runtime& runtime, const PropNameID& name, T&& value)
-    JSI_CONST_10 {
+    const {
   setPropertyValue(
       runtime, name, detail::toValue(runtime, std::forward<T>(value)));
 }
@@ -207,7 +205,6 @@ inline std::shared_ptr<HostObject> Object::getHostObject<HostObject>(
   return runtime.getHostObject(*this);
 }
 
-#if JSI_VERSION >= 7
 template <typename T>
 inline bool Object::hasNativeState(Runtime& runtime) const {
   return runtime.hasNativeState(*this) &&
@@ -230,26 +227,23 @@ inline void Object::setNativeState(
     std::shared_ptr<NativeState> state) const {
   runtime.setNativeState(*this, state);
 }
-#endif
 
-#if JSI_VERSION >= 11
 inline void Object::setExternalMemoryPressure(Runtime& runtime, size_t amt)
     const {
   runtime.setExternalMemoryPressure(*this, amt);
 }
-#endif
 
 inline Array Object::getPropertyNames(Runtime& runtime) const {
   return runtime.getPropertyNames(*this);
 }
 
-inline Value WeakObject::lock(Runtime& runtime) JSI_CONST_10 {
+inline Value WeakObject::lock(Runtime& runtime) const {
   return runtime.lockWeakObject(*this);
 }
 
 template <typename T>
 void Array::setValueAtIndex(Runtime& runtime, size_t i, T&& value)
-    JSI_CONST_10 {
+    const {
   setValueAtIndexImpl(
       runtime, i, detail::toValue(runtime, std::forward<T>(value)));
 }
@@ -356,11 +350,9 @@ inline Value Function::callAsConstructor(Runtime& runtime, Args&&... args)
       runtime, {detail::toValue(runtime, std::forward<Args>(args))...});
 }
 
-#if JSI_VERSION >= 8
 String BigInt::toString(Runtime& runtime, int radix) const {
   return runtime.bigintToString(*this, radix);
 }
-#endif
 
 } // namespace jsi
 } // namespace facebook

--- a/API/jsi/jsi/jsi.cpp
+++ b/API/jsi/jsi/jsi.cpp
@@ -32,10 +32,8 @@ std::string kindToString(const Value& v, Runtime* rt = nullptr) {
     return "a string";
   } else if (v.isSymbol()) {
     return "a symbol";
-#if JSI_VERSION >= 6
   } else if (v.isBigInt()) {
     return "a bigint";
-#endif
   } else {
     assert(v.isObject() && "Expecting object.");
     return rt != nullptr && v.getObject(*rt).isFunction(*rt) ? "a function"
@@ -68,9 +66,7 @@ Value callGlobalFunction(Runtime& runtime, const char* name, const Value& arg) {
 
 Buffer::~Buffer() = default;
 
-#if JSI_VERSION >= 9
 MutableBuffer::~MutableBuffer() = default;
-#endif
 
 PreparedJavaScript::~PreparedJavaScript() = default;
 
@@ -87,9 +83,7 @@ void HostObject::set(Runtime& rt, const PropNameID& name, const Value&) {
 
 HostObject::~HostObject() {}
 
-#if JSI_VERSION >= 7
 NativeState::~NativeState() {}
-#endif
 
 Runtime::~Runtime() {}
 
@@ -142,24 +136,12 @@ Instrumentation& Runtime::instrumentation() {
   return sharedInstance;
 }
 
-#if JSI_VERSION >= 2
 Value Runtime::createValueFromJsonUtf8(const uint8_t* json, size_t length) {
   Function parseJson = global()
                            .getPropertyAsObject(*this, "JSON")
                            .getPropertyAsFunction(*this, "parse");
   return parseJson.call(*this, String::createFromUtf8(*this, json, length));
 }
-#else
-Value Value::createFromJsonUtf8(
-    Runtime& runtime,
-    const uint8_t* json,
-    size_t length) {
-  Function parseJson = runtime.global()
-                           .getPropertyAsObject(runtime, "JSON")
-                           .getPropertyAsFunction(runtime, "parse");
-  return parseJson.call(runtime, String::createFromUtf8(runtime, json, length));
-}
-#endif
 
 Pointer& Pointer::operator=(Pointer&& other) {
   if (ptr_) {
@@ -258,10 +240,8 @@ Value::Value(Runtime& runtime, const Value& other) : Value(other.kind_) {
     data_.number = other.data_.number;
   } else if (kind_ == SymbolKind) {
     new (&data_.pointer) Pointer(runtime.cloneSymbol(other.data_.pointer.ptr_));
-#if JSI_VERSION >= 6
   } else if (kind_ == BigIntKind) {
     new (&data_.pointer) Pointer(runtime.cloneBigInt(other.data_.pointer.ptr_));
-#endif
   } else if (kind_ == StringKind) {
     new (&data_.pointer) Pointer(runtime.cloneString(other.data_.pointer.ptr_));
   } else if (kind_ >= ObjectKind) {
@@ -291,12 +271,10 @@ bool Value::strictEquals(Runtime& runtime, const Value& a, const Value& b) {
       return runtime.strictEquals(
           static_cast<const Symbol&>(a.data_.pointer),
           static_cast<const Symbol&>(b.data_.pointer));
-#if JSI_VERSION >= 6
     case BigIntKind:
       return runtime.strictEquals(
           static_cast<const BigInt&>(a.data_.pointer),
           static_cast<const BigInt&>(b.data_.pointer));
-#endif
     case StringKind:
       return runtime.strictEquals(
           static_cast<const String&>(a.data_.pointer),
@@ -364,7 +342,6 @@ Symbol Value::asSymbol(Runtime& rt) && {
   return std::move(*this).getSymbol(rt);
 }
 
-#if JSI_VERSION >= 6
 BigInt Value::asBigInt(Runtime& rt) const& {
   if (!isBigInt()) {
     throw JSError(
@@ -382,7 +359,6 @@ BigInt Value::asBigInt(Runtime& rt) && {
 
   return std::move(*this).getBigInt(rt);
 }
-#endif
 
 String Value::asString(Runtime& rt) const& {
   if (!isString()) {
@@ -407,7 +383,6 @@ String Value::toString(Runtime& runtime) const {
   return toString.call(runtime, *this).getString(runtime);
 }
 
-#if JSI_VERSION >= 8
 uint64_t BigInt::asUint64(Runtime& runtime) const {
   if (!isUint64(runtime)) {
     throw JSError(runtime, "Lossy truncation in BigInt64::asUint64");
@@ -421,7 +396,6 @@ int64_t BigInt::asInt64(Runtime& runtime) const {
   }
   return getInt64(runtime);
 }
-#endif
 
 Array Array::createWithElements(
     Runtime& rt,

--- a/API/jsi/jsi/jsi.h
+++ b/API/jsi/jsi/jsi.h
@@ -15,33 +15,33 @@
 #include <string>
 #include <vector>
 
-// JSI version defines set of features available in the API.
-// Each significant API change must be under a new version.
-// The JSI_VERSION can be provided as a parameter to compiler
-// or in the optional "jsi_version.h" file.
+// // JSI version defines set of features available in the API.
+// // Each significant API change must be under a new version.
+// // The JSI_VERSION can be provided as a parameter to compiler
+// // or in the optional "jsi_version.h" file.
 
-#ifndef JSI_VERSION
-#if defined(__has_include) && __has_include(<jsi/jsi-version.h>)
-#include <jsi/jsi-version.h>
-#endif
-#endif
+// #ifndef JSI_VERSION
+// #if defined(__has_include) && __has_include(<jsi/jsi-version.h>)
+// #include <jsi/jsi-version.h>
+// #endif
+// #endif
 
-#ifndef JSI_VERSION
-// Use the latest version by default
-#define JSI_VERSION 12
-#endif
+// #ifndef JSI_VERSION
+// // Use the latest version by default
+// #define JSI_VERSION 12
+// #endif
 
-#if JSI_VERSION >= 3
-#define JSI_NO_CONST_3
-#else
-#define JSI_NO_CONST_3 const
-#endif
+// #if JSI_VERSION >= 3
+// #define JSI_NO_CONST_3
+// #else
+// #define JSI_NO_CONST_3 const
+// #endif
 
-#if JSI_VERSION >= 10
-#define JSI_CONST_10 const
-#else
-#define JSI_CONST_10
-#endif
+// #if JSI_VERSION >= 10
+// #define const const
+// #else
+// #define const
+// #endif
 
 #ifndef JSI_EXPORT
 #ifdef _MSC_VER
@@ -84,7 +84,7 @@ class JSI_EXPORT StringBuffer : public Buffer {
   std::string s_;
 };
 
-#if JSI_VERSION >= 9
+//#if JSI_VERSION >= 9
 /// Base class for buffers of data that need to be passed to the runtime. The
 /// result of size() and data() must not change after construction. However, the
 /// region pointed to by data() may be modified by the user or the runtime. The
@@ -96,7 +96,7 @@ class JSI_EXPORT MutableBuffer {
   virtual size_t size() const = 0;
   virtual uint8_t* data() = 0;
 };
-#endif
+//#endif
 
 /// PreparedJavaScript is a base class representing JavaScript which is in a
 /// form optimized for execution, in a runtime-specific way. Construct one via
@@ -114,9 +114,9 @@ class Runtime;
 class Pointer;
 class PropNameID;
 class Symbol;
-#if JSI_VERSION >= 6
+//#if JSI_VERSION >= 6
 class BigInt;
-#endif
+//#endif
 class String;
 class Object;
 class WeakObject;
@@ -176,14 +176,14 @@ class JSI_EXPORT HostObject {
   virtual std::vector<PropNameID> getPropertyNames(Runtime& rt);
 };
 
-#if JSI_VERSION >= 7
+//#if JSI_VERSION >= 7
 /// Native state (and destructor) that can be attached to any JS object
 /// using setNativeState.
 class JSI_EXPORT NativeState {
  public:
   virtual ~NativeState();
 };
-#endif
+//#endif
 
 /// Represents a JS runtime.  Movable, but not copyable.  Note that
 /// this object may not be thread-aware, but cannot be used safely from
@@ -243,16 +243,16 @@ class JSI_EXPORT Runtime {
   virtual Value evaluatePreparedJavaScript(
       const std::shared_ptr<const PreparedJavaScript>& js) = 0;
 
-#if JSI_VERSION >= 12
+//#if JSI_VERSION >= 12
   /// Queues a microtask in the JavaScript VM internal Microtask (a.k.a. Job in
   /// ECMA262) queue, to be executed when the host drains microtasks in
   /// its event loop implementation.
   ///
   /// \param callback a function to be executed as a microtask.
   virtual void queueMicrotask(const jsi::Function& callback) = 0;
-#endif
+//#endif
 
-#if JSI_VERSION >= 4
+//#if JSI_VERSION >= 4
   /// Drain the JavaScript VM internal Microtask (a.k.a. Job in ECMA262) queue.
   ///
   /// \param maxMicrotasksHint a hint to tell an implementation that it should
@@ -281,7 +281,7 @@ class JSI_EXPORT Runtime {
   /// the time this is written, An implementation may swallow exceptions (JSC),
   /// may not pause (V8), and may not support bounded executions.
   virtual bool drainMicrotasks(int maxMicrotasksHint = -1) = 0;
-#endif
+//#endif
 
   /// \return the global object
   virtual Object global() = 0;
@@ -309,9 +309,9 @@ class JSI_EXPORT Runtime {
   friend class Pointer;
   friend class PropNameID;
   friend class Symbol;
-#if JSI_VERSION >= 6
+//#if JSI_VERSION >= 6
   friend class BigInt;
-#endif
+//#endif
   friend class String;
   friend class Object;
   friend class WeakObject;
@@ -335,9 +335,9 @@ class JSI_EXPORT Runtime {
   };
 
   virtual PointerValue* cloneSymbol(const Runtime::PointerValue* pv) = 0;
-#if JSI_VERSION >= 6
+//#if JSI_VERSION >= 6
   virtual PointerValue* cloneBigInt(const Runtime::PointerValue* pv) = 0;
-#endif
+//#endif
   virtual PointerValue* cloneString(const Runtime::PointerValue* pv) = 0;
   virtual PointerValue* cloneObject(const Runtime::PointerValue* pv) = 0;
   virtual PointerValue* clonePropNameID(const Runtime::PointerValue* pv) = 0;
@@ -349,22 +349,22 @@ class JSI_EXPORT Runtime {
       const uint8_t* utf8,
       size_t length) = 0;
   virtual PropNameID createPropNameIDFromString(const String& str) = 0;
-#if JSI_VERSION >= 5
+//#if JSI_VERSION >= 5
   virtual PropNameID createPropNameIDFromSymbol(const Symbol& sym) = 0;
-#endif
+//#endif
   virtual std::string utf8(const PropNameID&) = 0;
   virtual bool compare(const PropNameID&, const PropNameID&) = 0;
 
   virtual std::string symbolToString(const Symbol&) = 0;
 
-#if JSI_VERSION >= 8
+//#if JSI_VERSION >= 8
   virtual BigInt createBigIntFromInt64(int64_t) = 0;
   virtual BigInt createBigIntFromUint64(uint64_t) = 0;
   virtual bool bigintIsInt64(const BigInt&) = 0;
   virtual bool bigintIsUint64(const BigInt&) = 0;
   virtual uint64_t truncate(const BigInt&) = 0;
   virtual String bigintToString(const BigInt&, int) = 0;
-#endif
+//#endif
 
   virtual String createStringFromAscii(const char* str, size_t length) = 0;
   virtual String createStringFromUtf8(const uint8_t* utf8, size_t length) = 0;
@@ -372,33 +372,33 @@ class JSI_EXPORT Runtime {
 
   // \return a \c Value created from a utf8-encoded JSON string. The default
   // implementation creates a \c String and invokes JSON.parse.
-#if JSI_VERSION >= 2
+//#if JSI_VERSION >= 2
   virtual Value createValueFromJsonUtf8(const uint8_t* json, size_t length);
-#endif
+//#endif
 
   virtual Object createObject() = 0;
   virtual Object createObject(std::shared_ptr<HostObject> ho) = 0;
   virtual std::shared_ptr<HostObject> getHostObject(const jsi::Object&) = 0;
   virtual HostFunctionType& getHostFunction(const jsi::Function&) = 0;
 
-#if JSI_VERSION >= 7
+//#if JSI_VERSION >= 7
   virtual bool hasNativeState(const jsi::Object&) = 0;
   virtual std::shared_ptr<NativeState> getNativeState(const jsi::Object&) = 0;
   virtual void setNativeState(
       const jsi::Object&,
       std::shared_ptr<NativeState> state) = 0;
-#endif
+//#endif
 
   virtual Value getProperty(const Object&, const PropNameID& name) = 0;
   virtual Value getProperty(const Object&, const String& name) = 0;
   virtual bool hasProperty(const Object&, const PropNameID& name) = 0;
   virtual bool hasProperty(const Object&, const String& name) = 0;
   virtual void setPropertyValue(
-      JSI_CONST_10 Object&,
+      const Object&,
       const PropNameID& name,
       const Value& value) = 0;
   virtual void setPropertyValue(
-      JSI_CONST_10 Object&,
+      const Object&,
       const String& name,
       const Value& value) = 0;
 
@@ -410,19 +410,19 @@ class JSI_EXPORT Runtime {
   virtual Array getPropertyNames(const Object&) = 0;
 
   virtual WeakObject createWeakObject(const Object&) = 0;
-  virtual Value lockWeakObject(JSI_NO_CONST_3 JSI_CONST_10 WeakObject&) = 0;
+  virtual Value lockWeakObject(/*JSI_NO_CONST_3 const */ const WeakObject&) = 0;
 
   virtual Array createArray(size_t length) = 0;
-#if JSI_VERSION >= 9
+//#if JSI_VERSION >= 9
   virtual ArrayBuffer createArrayBuffer(
       std::shared_ptr<MutableBuffer> buffer) = 0;
-#endif
+//#endif
   virtual size_t size(const Array&) = 0;
   virtual size_t size(const ArrayBuffer&) = 0;
   virtual uint8_t* data(const ArrayBuffer&) = 0;
   virtual Value getValueAtIndex(const Array&, size_t i) = 0;
   virtual void
-  setValueAtIndexImpl(JSI_CONST_10 Array&, size_t i, const Value& value) = 0;
+  setValueAtIndexImpl(const Array&, size_t i, const Value& value) = 0;
 
   virtual Function createFunctionFromHostFunction(
       const PropNameID& name,
@@ -442,28 +442,28 @@ class JSI_EXPORT Runtime {
   virtual void popScope(ScopeState*);
 
   virtual bool strictEquals(const Symbol& a, const Symbol& b) const = 0;
-#if JSI_VERSION >= 6
+//#if JSI_VERSION >= 6
   virtual bool strictEquals(const BigInt& a, const BigInt& b) const = 0;
-#endif
+//#endif
   virtual bool strictEquals(const String& a, const String& b) const = 0;
   virtual bool strictEquals(const Object& a, const Object& b) const = 0;
 
   virtual bool instanceOf(const Object& o, const Function& f) = 0;
 
-#if JSI_VERSION >= 11
+//#if JSI_VERSION >= 11
   /// See Object::setExternalMemoryPressure.
   virtual void setExternalMemoryPressure(
       const jsi::Object& obj,
       size_t amount) = 0;
-#endif
+//#endif
 
   // These exist so derived classes can access the private parts of
   // Value, Symbol, String, and Object, which are all friends of Runtime.
   template <typename T>
   static T make(PointerValue* pv);
-#if JSI_VERSION >= 3
+//#if JSI_VERSION >= 3
   static PointerValue* getPointerValue(Pointer& pointer);
-#endif
+//#endif
   static const PointerValue* getPointerValue(const Pointer& pointer);
   static const PointerValue* getPointerValue(const Value& value);
 
@@ -543,12 +543,12 @@ class JSI_EXPORT PropNameID : public Pointer {
     return runtime.createPropNameIDFromString(str);
   }
 
-#if JSI_VERSION >= 5
+//#if JSI_VERSION >= 5
   /// Create a PropNameID from a JS symbol.
   static PropNameID forSymbol(Runtime& runtime, const jsi::Symbol& sym) {
     return runtime.createPropNameIDFromSymbol(sym);
   }
-#endif
+//#endif
 
   // Creates a vector of PropNameIDs constructed from given arguments.
   template <typename... Args>
@@ -601,7 +601,7 @@ class JSI_EXPORT Symbol : public Pointer {
   friend class Value;
 };
 
-#if JSI_VERSION >= 6
+//#if JSI_VERSION >= 6
 /// Represents a JS BigInt.  Movable, not copyable.
 class JSI_EXPORT BigInt : public Pointer {
  public:
@@ -610,7 +610,7 @@ class JSI_EXPORT BigInt : public Pointer {
   BigInt(BigInt&& other) = default;
   BigInt& operator=(BigInt&& other) = default;
 
-#if JSI_VERSION >= 8
+//#if JSI_VERSION >= 8
   /// Create a BigInt representing the signed 64-bit \p value.
   static BigInt fromInt64(Runtime& runtime, int64_t value) {
     return runtime.createBigIntFromInt64(value);
@@ -657,12 +657,12 @@ class JSI_EXPORT BigInt : public Pointer {
   /// \returns this BigInt converted to a String in base \p radix. Throws a
   /// JSIException if radix is not in the [2, 36] range.
   inline String toString(Runtime& runtime, int radix = 10) const;
-#endif
+//#endif
 
   friend class Runtime;
   friend class Value;
 };
-#endif
+//#endif
 
 /// Represents a JS String.  Movable, not copyable.
 class JSI_EXPORT String : public Pointer {
@@ -747,7 +747,7 @@ class JSI_EXPORT Object : public Pointer {
   }
 
   /// \return the result of `this instanceOf ctor` in JS.
-  bool instanceOf(Runtime& rt, const Function& ctor) JSI_CONST_10 {
+  bool instanceOf(Runtime& rt, const Function& ctor) const {
     return rt.instanceOf(*this, ctor);
   }
 
@@ -782,21 +782,21 @@ class JSI_EXPORT Object : public Pointer {
   /// used to make one: nullptr_t, bool, double, int, const char*,
   /// String, or Object.
   template <typename T>
-  void setProperty(Runtime& runtime, const char* name, T&& value) JSI_CONST_10;
+  void setProperty(Runtime& runtime, const char* name, T&& value) const;
 
   /// Sets the property value from a Value or anything which can be
   /// used to make one: nullptr_t, bool, double, int, const char*,
   /// String, or Object.
   template <typename T>
   void setProperty(Runtime& runtime, const String& name, T&& value)
-      JSI_CONST_10;
+      const;
 
   /// Sets the property value from a Value or anything which can be
   /// used to make one: nullptr_t, bool, double, int, const char*,
   /// String, or Object.
   template <typename T>
   void setProperty(Runtime& runtime, const PropNameID& name, T&& value)
-      JSI_CONST_10;
+      const;
 
   /// \return true iff JS \c Array.isArray() would return \c true.  If
   /// so, then \c getArray() will succeed.
@@ -879,7 +879,7 @@ class JSI_EXPORT Object : public Pointer {
   template <typename T = HostObject>
   std::shared_ptr<T> asHostObject(Runtime& runtime) const;
 
-#if JSI_VERSION >= 7
+//#if JSI_VERSION >= 7
   /// \return whether this object has native state of type T previously set by
   /// \c setNativeState.
   template <typename T = NativeState>
@@ -898,7 +898,7 @@ class JSI_EXPORT Object : public Pointer {
   /// Throws a type error if this object is a proxy or host object.
   void setNativeState(Runtime& runtime, std::shared_ptr<NativeState> state)
       const;
-#endif
+//#endif
 
   /// \return same as \c getProperty(name).asObject(), except with
   /// a better exception message.
@@ -916,7 +916,7 @@ class JSI_EXPORT Object : public Pointer {
   /// works.  I only need it in one place.)
   Array getPropertyNames(Runtime& runtime) const;
 
-#if JSI_VERSION >= 11
+//#if JSI_VERSION >= 11
   /// Inform the runtime that there is additional memory associated with a given
   /// JavaScript object that is not visible to the GC. This can be used if an
   /// object is known to retain some native memory, and may be used to guide
@@ -926,20 +926,20 @@ class JSI_EXPORT Object : public Pointer {
   /// collected, the associated external memory will be considered freed and may
   /// no longer factor into GC decisions.
   void setExternalMemoryPressure(Runtime& runtime, size_t amt) const;
-#endif
+//#endif
 
  protected:
   void setPropertyValue(
       Runtime& runtime,
       const String& name,
-      const Value& value) JSI_CONST_10 {
+      const Value& value) const {
     return runtime.setPropertyValue(*this, name, value);
   }
 
   void setPropertyValue(
       Runtime& runtime,
       const PropNameID& name,
-      const Value& value) JSI_CONST_10 {
+      const Value& value) const {
     return runtime.setPropertyValue(*this, name, value);
   }
 
@@ -965,7 +965,7 @@ class JSI_EXPORT WeakObject : public Pointer {
   /// otherwise returns \c undefined.  Note that this method has nothing to do
   /// with threads or concurrency.  The name is based on std::weak_ptr::lock()
   /// which serves a similar purpose.
-  Value lock(Runtime& runtime) JSI_CONST_10;
+  Value lock(Runtime& runtime) const;
 
   friend class Runtime;
 };
@@ -1001,7 +1001,7 @@ class JSI_EXPORT Array : public Object {
   /// value behaves as with Object::setProperty().  If \c i is out of
   /// range [ 0..\c length ] throws a JSIException.
   template <typename T>
-  void setValueAtIndex(Runtime& runtime, size_t i, T&& value) JSI_CONST_10;
+  void setValueAtIndex(Runtime& runtime, size_t i, T&& value) const;
 
   /// There is no current API for changing the size of an array once
   /// created.  We'll probably need that eventually.
@@ -1021,7 +1021,7 @@ class JSI_EXPORT Array : public Object {
   friend class Runtime;
 
   void setValueAtIndexImpl(Runtime& runtime, size_t i, const Value& value)
-      JSI_CONST_10 {
+      const {
     return runtime.setValueAtIndexImpl(*this, i, value);
   }
 
@@ -1034,10 +1034,10 @@ class JSI_EXPORT ArrayBuffer : public Object {
   ArrayBuffer(ArrayBuffer&&) = default;
   ArrayBuffer& operator=(ArrayBuffer&&) = default;
 
-#if JSI_VERSION >= 9
+//#if JSI_VERSION >= 9
   ArrayBuffer(Runtime& runtime, std::shared_ptr<MutableBuffer> buffer)
       : ArrayBuffer(runtime.createArrayBuffer(std::move(buffer))) {}
-#endif
+//#endif
 
   /// \return the size of the ArrayBuffer storage. This is not affected by
   /// overriding the byteLength property.
@@ -1050,7 +1050,7 @@ class JSI_EXPORT ArrayBuffer : public Object {
     return runtime.size(*this);
   }
 
-  uint8_t* data(Runtime& runtime) JSI_CONST_10 {
+  uint8_t* data(Runtime& runtime) const {
     return runtime.data(*this);
   }
 
@@ -1202,9 +1202,9 @@ class JSI_EXPORT Value {
       typename T,
       typename = std::enable_if_t<
           std::is_base_of<Symbol, T>::value ||
-#if JSI_VERSION >= 6
+//#if JSI_VERSION >= 6
           std::is_base_of<BigInt, T>::value ||
-#endif
+//#endif
           std::is_base_of<String, T>::value ||
           std::is_base_of<Object, T>::value>>
   /* implicit */ Value(T&& other) : Value(kindOf(other)) {
@@ -1227,12 +1227,12 @@ class JSI_EXPORT Value {
     new (&data_.pointer) Symbol(runtime.cloneSymbol(sym.ptr_));
   }
 
-#if JSI_VERSION >= 6
+//#if JSI_VERSION >= 6
   /// Copies a BigInt lvalue into a new JS value.
   Value(Runtime& runtime, const BigInt& bigint) : Value(BigIntKind) {
     new (&data_.pointer) BigInt(runtime.cloneBigInt(bigint.ptr_));
   }
-#endif
+//#endif
 
   /// Copies a String lvalue into a new JS value.
   Value(Runtime& runtime, const String& str) : Value(StringKind) {
@@ -1270,13 +1270,13 @@ class JSI_EXPORT Value {
   // \return a \c Value created from a utf8-encoded JSON string.
   static Value
   createFromJsonUtf8(Runtime& runtime, const uint8_t* json, size_t length)
-#if JSI_VERSION >= 2
+//#if JSI_VERSION >= 2
   {
     return runtime.createValueFromJsonUtf8(json, length);
   }
-#else
-      ;
-#endif
+//#else
+//      ;
+//#endif
 
   /// \return according to the Strict Equality Comparison algorithm, see:
   /// https://262.ecma-international.org/11.0/#sec-strict-equality-comparison
@@ -1308,11 +1308,11 @@ class JSI_EXPORT Value {
     return kind_ == StringKind;
   }
 
-#if JSI_VERSION >= 6
+//#if JSI_VERSION >= 6
   bool isBigInt() const {
     return kind_ == BigIntKind;
   }
-#endif
+//#endif
 
   bool isSymbol() const {
     return kind_ == SymbolKind;
@@ -1362,7 +1362,7 @@ class JSI_EXPORT Value {
   Symbol asSymbol(Runtime& runtime) const&;
   Symbol asSymbol(Runtime& runtime) &&;
 
-#if JSI_VERSION >= 6
+//#if JSI_VERSION >= 6
   /// \return the BigInt value, or asserts if not a bigint.
   BigInt getBigInt(Runtime& runtime) const& {
     assert(isBigInt());
@@ -1382,7 +1382,7 @@ class JSI_EXPORT Value {
   /// bigint
   BigInt asBigInt(Runtime& runtime) const&;
   BigInt asBigInt(Runtime& runtime) &&;
-#endif
+//#endif
 
   /// \return the String value, or asserts if not a string.
   String getString(Runtime& runtime) const& {
@@ -1436,9 +1436,9 @@ class JSI_EXPORT Value {
     BooleanKind,
     NumberKind,
     SymbolKind,
-#if JSI_VERSION >= 6
+//#if JSI_VERSION >= 6
     BigIntKind,
-#endif
+//#endif
     StringKind,
     ObjectKind,
     PointerKind = SymbolKind,
@@ -1465,11 +1465,11 @@ class JSI_EXPORT Value {
   constexpr static ValueKind kindOf(const Symbol&) {
     return SymbolKind;
   }
-#if JSI_VERSION >= 6
+//#if JSI_VERSION >= 6
   constexpr static ValueKind kindOf(const BigInt&) {
     return BigIntKind;
   }
-#endif
+//#endif
   constexpr static ValueKind kindOf(const String&) {
     return StringKind;
   }

--- a/API/jsi/jsi/test/testlib_ext.cpp
+++ b/API/jsi/jsi/test/testlib_ext.cpp
@@ -68,7 +68,6 @@ TEST_P(JSITestExt, ArrayBufferTest) {
   EXPECT_EQ(buffer[1], 5678);
 }
 
-#if JSI_VERSION >= 9
 TEST_P(JSITestExt, ExternalArrayBufferTest) {
   struct FixedBuffer : MutableBuffer {
     size_t size() const override {
@@ -297,7 +296,6 @@ TEST_P(JSITestExt, HostObjectAsParentTest) {
       eval("var subClass = {__proto__: ho}; subClass.prop1 == 10;").getBool());
 }
 
-#if JSI_VERSION >= 7
 TEST_P(JSITestExt, NativeStateTest) {
   class C : public facebook::jsi::NativeState {
    public:
@@ -343,9 +341,7 @@ TEST_P(JSITestExt, NativeStateTest) {
   // point to local variables. Otherwise ASAN will complain.
   eval("gc()");
 }
-#endif
 
-#if JSI_VERSION >= 5
 TEST_P(JSITestExt, PropNameIDFromSymbol) {
   auto strProp = PropNameID::forAscii(rt, "a");
   auto secretProp = PropNameID::forSymbol(
@@ -360,7 +356,6 @@ TEST_P(JSITestExt, PropNameIDFromSymbol) {
   EXPECT_EQ(x.getProperty(rt, secretProp).getString(rt).utf8(rt), "secret");
   EXPECT_EQ(x.getProperty(rt, globalProp).getString(rt).utf8(rt), "global");
 }
-#endif
 
 TEST_P(JSITestExt, HasComputedTest) {
   // The only use of JSObject::hasComputed() is in HermesRuntimeImpl,
@@ -394,9 +389,7 @@ TEST_P(JSITestExt, GlobalObjectTest) {
   eval("gc()");
   EXPECT_EQ(eval("f(10)").getNumber(), 15);
 }
-#endif
 
-#if JSI_VERSION >= 8
 TEST_P(JSITestExt, BigIntJSI) {
   Function bigintCtor = rt.global().getPropertyAsFunction(rt, "BigInt");
   auto BigInt = [&](const char* v) { return bigintCtor.call(rt, eval(v)); };
@@ -525,7 +518,6 @@ TEST_P(JSITestExt, BigIntJSITruncation) {
   EXPECT_EQ(toUint64(b), lossy(~0ull));
   EXPECT_EQ(toInt64(b), lossy(~0ull));
 }
-#endif
 
 TEST_P(JSITestExt, NativeExceptionDoesNotUseGlobalError) {
   Function alwaysThrows = Function::createFromHostFunction(

--- a/unittests/API/APITest.cpp
+++ b/unittests/API/APITest.cpp
@@ -132,7 +132,6 @@ TEST_P(HermesRuntimeTest, ArrayBufferTest) {
   }
 }
 
-#if JSI_VERSION >= 9
 class HermesRuntimeTestMethodsTest : public HermesRuntimeCustomConfigTest {
  public:
   HermesRuntimeTestMethodsTest()
@@ -195,7 +194,6 @@ TEST_F(HermesRuntimeTestMethodsTest, ExternalArrayBufferTest) {
     EXPECT_TRUE(weakBuf.expired());
   }
 }
-#endif
 
 TEST_F(HermesRuntimeTestMethodsTest, DetachedArrayBuffer) {
   auto ab = eval(
@@ -756,7 +754,6 @@ TEST_P(HermesRuntimeTest, HostObjectAsParentTest) {
       eval("var subClass = {__proto__: ho}; subClass.prop1 == 10;").getBool());
 }
 
-#if JSI_VERSION >= 7
 TEST_P(HermesRuntimeTest, NativeStateTest) {
   class C : public facebook::jsi::NativeState {
    public:
@@ -801,9 +798,7 @@ TEST_P(HermesRuntimeTest, NativeStateTest) {
   // point to local variables. Otherwise ASAN will complain.
   eval("gc()");
 }
-#endif
 
-#if JSI_VERSION >= 5
 TEST_P(HermesRuntimeTest, ExternalMemoryTest) {
   // Keep track of the number of NativeState instances to make sure they are
   // being freed by the GC when there is memory pressure associated with the
@@ -862,7 +857,6 @@ TEST_P(HermesRuntimeTest, PropNameIDFromSymbol) {
   EXPECT_EQ(x.getProperty(*rt, secretProp).getString(*rt).utf8(*rt), "secret");
   EXPECT_EQ(x.getProperty(*rt, globalProp).getString(*rt).utf8(*rt), "global");
 }
-#endif
 
 TEST_P(HermesRuntimeTest, HasComputedTest) {
   // The only use of JSObject::hasComputed() is in HermesRuntimeImpl,
@@ -977,7 +971,6 @@ TEST_P(HermesRuntimeTest, DiagnosticHandlerTestWarning) {
   EXPECT_EQ(5, diagHandler.ds[1].ranges[0].second);
 }
 
-#if JSI_VERSION >= 8
 TEST_P(HermesRuntimeTest, BigIntJSI) {
   Function bigintCtor = rt->global().getPropertyAsFunction(*rt, "BigInt");
   auto BigInt = [&](const char *v) { return bigintCtor.call(*rt, eval(v)); };
@@ -1108,7 +1101,6 @@ TEST_P(HermesRuntimeTest, BigIntJSITruncation) {
   EXPECT_EQ(toUint64(b), lossy(~0ull));
   EXPECT_EQ(toInt64(b), lossy(~0ull));
 }
-#endif
 
 #ifdef HERMESVM_EXCEPTION_ON_OOM
 class HermesRuntimeTestSmallHeap : public HermesRuntimeCustomConfigTest {

--- a/unittests/API/SynthTraceTest.cpp
+++ b/unittests/API/SynthTraceTest.cpp
@@ -517,7 +517,6 @@ TEST_F(SynthTraceTest, CallObjectGetProp) {
       *records[8]);
 }
 
-#if JSI_VERSION >= 4
 TEST_F(SynthTraceTest, DrainMicrotasks) {
   {
     rt->drainMicrotasks();
@@ -529,7 +528,6 @@ TEST_F(SynthTraceTest, DrainMicrotasks) {
   EXPECT_EQ_RECORD(
       SynthTrace::DrainMicrotasksRecord(dummyTime, 5), *records[1]);
 }
-#endif
 
 TEST_F(SynthTraceTest, HostObjectProxy) {
   // This allows us to share the constant strings between the outer scope
@@ -939,7 +937,6 @@ TEST_F(SynthTraceTest, HostObjectPropertyNamesAreDefs) {
   EXPECT_EQ_RECORD(gprExpect4, *records[19]);
 }
 
-#if JSI_VERSION >= 8
 TEST_F(SynthTraceTest, CreateBigInt) {
   SynthTrace::ObjectID fromInt64ID =
       rt->getUniqueID(jsi::BigInt::fromInt64(*rt, 0xffffffffffffffff));
@@ -982,7 +979,6 @@ TEST_F(SynthTraceTest, BigIntToString) {
   EXPECT_EQ_RECORD(
       SynthTrace::BigIntToStringRecord(dummyTime, strID, bID, 16), *records[1]);
 }
-#endif
 
 // These tests fail on Windows.
 #if defined(EXPECT_DEATH_IF_SUPPORTED) && !defined(_WINDOWS)
@@ -1212,18 +1208,14 @@ TEST_F(SynthTraceReplayTest, SetPropertyReplay) {
         jsi::PropNameID::forString(rt, jsi::String::createFromAscii(rt, "c"));
     rt.global().setProperty(rt, "symD", eval(rt, "Symbol('d')"));
     rt.global().setProperty(rt, "symE", eval(rt, "Symbol('e')"));
-#if JSI_VERSION >= 5
     auto symProp = jsi::PropNameID::forSymbol(
         rt, rt.global().getProperty(rt, "symE").asSymbol(rt));
-#endif
 
     jsi::Object x(rt);
     x.setProperty(rt, asciiProp, "apple");
     x.setProperty(rt, utf8Prop, "banana");
     x.setProperty(rt, strProp, "coconut");
-#if JSI_VERSION >= 5
     x.setProperty(rt, symProp, "eggplant");
-#endif
     rt.global().setProperty(rt, "x", x);
     eval(rt, "x[symD] = 'durian'");
   }
@@ -1234,13 +1226,10 @@ TEST_F(SynthTraceReplayTest, SetPropertyReplay) {
     EXPECT_EQ(eval(rt, "x.b").asString(rt).utf8(rt), "banana");
     EXPECT_EQ(eval(rt, "x.c").asString(rt).utf8(rt), "coconut");
     EXPECT_EQ(eval(rt, "x[symD]").asString(rt).utf8(rt), "durian");
-#if JSI_VERSION >= 5
     EXPECT_EQ(eval(rt, "x[symE]").asString(rt).utf8(rt), "eggplant");
-#endif
   }
 }
 
-#if JSI_VERSION >= 8
 TEST_F(SynthTraceReplayTest, BigIntCreate) {
   {
     auto &rt = *traceRt;
@@ -1267,9 +1256,7 @@ TEST_F(SynthTraceReplayTest, BigIntCreate) {
     EXPECT_EQ(uint64String.utf8(rt), "1777777777777777777777");
   }
 }
-#endif
 
-#if JSI_VERSION >= 4
 TEST_F(SynthTraceReplayTest, HostObjectManipulation) {
   // HostObject for testing.
   // It allows to set either number or string property.
@@ -1532,9 +1519,7 @@ HermesInternal.enqueueJob(inc);
     EXPECT_EQ(eval(rt, "x").asNumber(), 3);
   }
 }
-#endif
 
-#if JSI_VERSION >= 12
 TEST_F(JobQueueReplayTest, QueueMicrotask) {
   {
     auto &rt = *traceRt;
@@ -1552,7 +1537,6 @@ TEST_F(JobQueueReplayTest, QueueMicrotask) {
     EXPECT_EQ(eval(rt, "x").asNumber(), 4);
   }
 }
-#endif
 
 using NonDeterminismReplayTest = SynthTraceReplayTest;
 
@@ -1635,7 +1619,6 @@ var x = ref.deref().x;
   EXPECT_EQ(traceX, replayX);
 }
 
-#if JSI_VERSION >= 4
 TEST_F(NonDeterminismReplayTest, WeakRefTest) {
   eval(*traceRt, R"(
 var obj = {x: 5};
@@ -1807,7 +1790,6 @@ TEST(SynthTraceReplayTestNoFixture, ExternalMemoryTest) {
     EXPECT_EQ(amounts[i], replayRt->amounts[i]);
   }
 }
-#endif
 
 /// @}
 


### PR DESCRIPTION
## Summary

The removal of the JSI version is necessary because it is no longer required for the current implementation. 
Initially, the JSI version was used to handle different versions of the JSI API, ensuring compatibility. 
However, since the project now exclusively uses the ABI stable API, the JSI version has become redundant and causes conflicts during merges. Removing it simplifies the codebase and reduces the effort needed to integrate the latest versions of Hermes.

## Test Plan

- Build successfully 
- Run the Unit tests, ensure UT results are in same state before and after the change


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/209)