### PR TITLE
Implement jsr_queue_microtask

### DIFF
--- a/API/hermes_node_api_jsi/ApiLoaders/JSRuntimeApi.inc
+++ b/API/hermes_node_api_jsi/ApiLoaders/JSRuntimeApi.inc
@@ -17,6 +17,7 @@
 JSR_FUNC(jsr_collect_garbage)
 JSR_FUNC(jsr_config_enable_gc_api)
 JSR_FUNC(jsr_config_enable_inspector)
+JSR_FUNC(jsr_config_set_explicit_microtasks)
 JSR_FUNC(jsr_config_set_inspector_break_on_start)
 JSR_FUNC(jsr_config_set_inspector_port)
 JSR_FUNC(jsr_config_set_inspector_runtime_name)

--- a/API/hermes_shared/hermes_win.cpp
+++ b/API/hermes_shared/hermes_win.cpp
@@ -383,6 +383,11 @@ class ConfigWrapper {
     return napi_status::napi_ok;
   }
 
+  napi_status setExplicitMicrotasks(bool value) {
+    explicitMicrotasks_ = value;
+    return napi_status::napi_ok;
+  }
+
   napi_status setTaskRunner(std::unique_ptr<TaskRunner> taskRunner) {
     taskRunner_ = std::move(taskRunner);
     return napi_status::napi_ok;
@@ -427,7 +432,7 @@ class ConfigWrapper {
       auto crashManager = std::make_shared<CrashManagerImpl>();
       config.withCrashMgr(crashManager);
     }
-    config.withMicrotaskQueue(true);
+    config.withMicrotaskQueue(explicitMicrotasks_);
     return config.build();
   }
 
@@ -437,6 +442,7 @@ class ConfigWrapper {
   std::string inspectorRuntimeName_;
   uint16_t inspectorPort_{};
   bool inspectorBreakOnStart_{};
+  bool explicitMicrotasks_{};
   std::shared_ptr<TaskRunner> taskRunner_;
   std::shared_ptr<ScriptCache> scriptCache_;
 };
@@ -622,6 +628,10 @@ JSR_API jsr_config_set_inspector_break_on_start(jsr_config config, bool value) {
 JSR_API jsr_config_enable_gc_api(jsr_config /*config*/, bool /*value*/) {
   // We do nothing for now.
   return napi_ok;
+}
+
+JSR_API jsr_config_set_explicit_microtasks(jsr_config config, bool value) {
+  return CHECKED_CONFIG(config)->setExplicitMicrotasks(value);
 }
 
 JSR_API jsr_config_set_task_runner(

--- a/API/hermes_shared/hermes_win.cpp
+++ b/API/hermes_shared/hermes_win.cpp
@@ -427,6 +427,7 @@ class ConfigWrapper {
       auto crashManager = std::make_shared<CrashManagerImpl>();
       config.withCrashMgr(crashManager);
     }
+    config.withMicrotaskQueue(true);
     return config.build();
   }
 

--- a/API/hermes_shared/node-api/js_runtime_api.h
+++ b/API/hermes_shared/node-api/js_runtime_api.h
@@ -49,6 +49,8 @@ JSR_API jsr_config_set_inspector_break_on_start(jsr_config config, bool value);
 
 JSR_API jsr_config_enable_gc_api(jsr_config config, bool value);
 
+JSR_API jsr_config_set_explicit_microtasks(jsr_config config, bool value);
+
 //=============================================================================
 // jsr_config task runner
 //=============================================================================

--- a/API/hermes_shared/node-api/js_runtime_api.h
+++ b/API/hermes_shared/node-api/js_runtime_api.h
@@ -128,8 +128,7 @@ JSR_API jsr_close_napi_env_scope(napi_env env, jsr_napi_env_scope scope);
 JSR_API jsr_get_description(napi_env env, const char** result);
 
 // To implement JSI queueMicrotask()
-JSR_API
-jsr_queue_microtask(napi_env env, napi_value callback);
+JSR_API jsr_queue_microtask(napi_env env, napi_value callback);
 
 // To implement JSI drainMicrotasks()
 JSR_API

--- a/API/jsi/jsi/jsi.cpp
+++ b/API/jsi/jsi/jsi.cpp
@@ -170,7 +170,7 @@ std::u16string convertUTF8ToUTF16(const std::string& utf8) {
 #if JSI_VERSION >= 19
 // Given a unsigned number, which is less than 16, return the hex character.
 inline char hexDigit(unsigned x) {
-  return x < 10 ? '0' + x : 'A' + (x - 10);
+  return static_cast<char>(x < 10 ? '0' + x : 'A' + (x - 10));
 }
 
 // Given a sequence of UTF 16 code units, return true if all code units are


### PR DESCRIPTION
Currently RN for Windows fails to move to newer versions because it requires the new JSI function `queueMicrotask`.
This function was added in `JSI_VERSION` 12, but it was not implemented in the ABI-stable API.
This PR implements the `jsr_queue_microtask` C function that has the same functionality as the JSI for Hermes implementation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/214)