### PR TITLE
Fix Nuget compatibility for UWP platforms

### DIFF
--- a/.ado/nuget/Microsoft.JavaScript.Hermes.nuspec
+++ b/.ado/nuget/Microsoft.JavaScript.Hermes.nuspec
@@ -28,6 +28,7 @@
           target="build\native\Microsoft.JavaScript.Hermes$fat_suffix$.props" />
     <file src="$nugetroot$\build\native\Microsoft.JavaScript.Hermes.targets"
           target="build\native\Microsoft.JavaScript.Hermes$fat_suffix$.targets" />
+    <file src="$nugetroot$\lib\uap\_._" target="build\uap\" />
     <file src="$nugetroot$\license\*" target="" />
     <file src="$nugetroot$\tools\**\*.*" target="tools" />
   </files>


### PR DESCRIPTION
It seems that the building pipeline redesign introduced an issue where the `Microsoft.JavaScript.Hermes` Nuget packages do not work with UWP anymore. It is caused by accidental removal of the `build\uap\_._` file from the Nuget packages.

This PR fixes the issue by adding back the `build/uap/_._` file to the `.nuspec` file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/215)