### PR TITLE
Fixing stackoverflow test for recursion

### DIFF
--- a/API/jsi/jsi/test/testlib.cpp
+++ b/API/jsi/jsi/test/testlib.cpp
@@ -1065,8 +1065,7 @@ TEST_P(JSITest, JSErrorDoesNotInfinitelyRecurse) {
 
   rt.global().setProperty(rt, "Error", globalError);
 }
-// TODO: (vmoroz) Restore after JSI for Node-API is fixed.
-#if 0
+
 TEST_P(JSITest, JSErrorStackOverflowHandling) {
   rt.global().setProperty(
       rt,
@@ -1084,13 +1083,12 @@ TEST_P(JSITest, JSErrorStackOverflowHandling) {
             return function("function() { return 0; }").call(rt);
           }));
   try {
-    eval("(function f() { callSomething(); f.apply(); })()");
+    eval("(function f() { callSomething(); f(); })()");
     FAIL();
   } catch (const JSError& ex) {
     EXPECT_NE(std::string(ex.what()).find("exceeded"), std::string::npos);
   }
 }
-#endif
 
 TEST_P(JSITest, ScopeDoesNotCrashTest) {
   Scope scope(rt);


### PR DESCRIPTION
changing f.apply() to f() , both are same.

![image](https://github.com/user-attachments/assets/da238660-f2a6-4624-bd8d-e699107f4923)
