### PR TITLE
synchronize Internationalization code on Hermes-windows with Hermes-Meta

### DIFF
--- a/include/hermes/Platform/Unicode/icu.h
+++ b/include/hermes/Platform/Unicode/icu.h
@@ -31,13 +31,13 @@
 #define U_HIDE_OBSOLETE_API 1
 #define U_HIDE_INTERNAL_API 1
 #define U_NO_DEFAULT_INCLUDE_UTF_HEADERS 1
-// #include "unicode/ucnv.h"
-// #include "unicode/ucol.h"
-// #include "unicode/udat.h"
-// #include "unicode/uloc.h"
-// #include "unicode/uniset.h"
-// #include "unicode/unorm2.h"
-// #include "unicode/ustring.h"
+#include "unicode/ucnv.h"
+#include "unicode/ucol.h"
+#include "unicode/udat.h"
+#include "unicode/uloc.h"
+#include "unicode/uniset.h"
+#include "unicode/unorm2.h"
+#include "unicode/ustring.h"
 #include <icucommon.h>
 #include <icui18n.h>
 #elif defined(__ANDROID__) && defined(HERMES_FACEBOOK_BUILD)

--- a/lib/Platform/Intl/CMakeLists.txt
+++ b/lib/Platform/Intl/CMakeLists.txt
@@ -23,7 +23,7 @@ if(HERMES_ENABLE_INTL)
     target_compile_options(hermesPlatformIntl PRIVATE -fobjc-arc)
   else()
     add_hermes_library(hermesPlatformIntl STATIC
-        PlatformIntlICU.cpp
+        # PlatformIntlICU.cpp # To be uncommented after Intl is enabled. 
         PlatformIntlShared.cpp
         PlatformIntlWindows.cpp
         impl_icu/Collator.cpp

--- a/lib/Platform/Intl/CMakeLists.txt
+++ b/lib/Platform/Intl/CMakeLists.txt
@@ -22,6 +22,20 @@ if(HERMES_ENABLE_INTL)
     set_target_properties(hermesPlatformIntl PROPERTIES UNITY_BUILD false)
     target_compile_options(hermesPlatformIntl PRIVATE -fobjc-arc)
   else()
-    add_hermes_library(hermesPlatformIntl STATIC PlatformIntlWindows.cpp LINK_LIBS hermesPublic)
+    add_hermes_library(hermesPlatformIntl STATIC
+        PlatformIntlICU.cpp
+        PlatformIntlShared.cpp
+        PlatformIntlWindows.cpp
+        impl_icu/Collator.cpp
+        impl_icu/IntlUtils.cpp
+        impl_icu/LocaleConverter.cpp
+        impl_icu/LocaleBCP47Object.cpp
+        impl_icu/LocaleResolver.cpp
+        impl_icu/OptionHelpers.cpp
+        LINK_LIBS
+        hermesBCP47Parser
+        hermesPublic
+    )
+    hermes_link_icu(hermesPlatformIntl)
   endif()
 endif()

--- a/lib/Platform/Intl/CMakeLists.txt
+++ b/lib/Platform/Intl/CMakeLists.txt
@@ -30,7 +30,7 @@ if(HERMES_ENABLE_INTL)
         impl_icu/IntlUtils.cpp
         impl_icu/LocaleConverter.cpp
         impl_icu/LocaleBCP47Object.cpp
-        impl_icu/LocaleResolver.cpp
+        # impl_icu/LocaleResolver.cpp # To be uncommented after Intl is enabled.
         impl_icu/OptionHelpers.cpp
         LINK_LIBS
         hermesBCP47Parser

--- a/lib/Platform/Intl/PlatformIntlShared.cpp
+++ b/lib/Platform/Intl/PlatformIntlShared.cpp
@@ -5,13 +5,34 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// This file includes shared code between Apple and Windows implementation of Intl APIs
+// This file includes shared code between Apple, Windows and ICU implementation of
+// Intl APIs
+#include "hermes/Platform/Intl/PlatformIntlShared.h"
 #include "hermes/Platform/Intl/PlatformIntl.h"
+#include "impl_icu/LocaleBCP47Object.h"
 
 using namespace ::hermes;
 
 namespace hermes {
 namespace platform_intl {
+
+// https://tc39.es/ecma402/#sec-intl.getcanonicallocales
+vm::CallResult<std::vector<std::u16string>> getCanonicalLocales(
+    vm::Runtime &runtime,
+    const std::vector<std::u16string> &locales) {
+  // 1. Let ll be ? CanonicalizeLocaleList(locales).
+  auto localeBcp47ObjectsRes =
+      impl_icu::LocaleBCP47Object::canonicalizeLocaleList(runtime, locales);
+  if (LLVM_UNLIKELY(localeBcp47ObjectsRes == vm::ExecutionStatus::EXCEPTION)) {
+    return vm::ExecutionStatus::EXCEPTION;
+  }
+  // 2. Return CreateArrayFromList(ll).
+  std::vector<std::u16string> canonicalLocales;
+  for (const auto &localeBcp47Object : *localeBcp47ObjectsRes) {
+    canonicalLocales.push_back(localeBcp47Object.getCanonicalizedLocaleId());
+  }
+  return canonicalLocales;
+}
 
 // https://402.ecma-international.org/8.0/#sec-bestavailablelocale
 std::optional<std::u16string> bestAvailableLocale(
@@ -87,7 +108,7 @@ std::optional<bool> getOptionBool(
 }
 
 // Implementation of
-// https://402.ecma-international.org/8.0/#sec-todatetimeoptions
+/// https://402.ecma-international.org/8.0/#sec-todatetimeoptions
 vm::CallResult<Options> toDateTimeOptions(
     vm::Runtime &runtime,
     Options options,
@@ -170,6 +191,20 @@ vm::CallResult<Options> toDateTimeOptions(
   }
   // 13. return options
   return options;
+}
+
+/// https://402.ecma-international.org/8.0/#sec-case-sensitivity-and-case-mapping
+std::u16string toASCIIUppercase(std::u16string_view tz) {
+  std::u16string result;
+  std::uint8_t offset = 'a' - 'A';
+  for (char16_t c16 : tz) {
+    if (c16 >= 'a' && c16 <= 'z') {
+      result.push_back((char)c16 - offset);
+    } else {
+      result.push_back(c16);
+    }
+  }
+  return result;
 }
 
 } // namespace platform_intl

--- a/lib/Platform/Intl/PlatformIntlShared.cpp
+++ b/lib/Platform/Intl/PlatformIntlShared.cpp
@@ -17,6 +17,7 @@ namespace hermes {
 namespace platform_intl {
 
 // https://tc39.es/ecma402/#sec-intl.getcanonicallocales
+/* To Do - There is already impl of this function in PlatformWindows.cpp.
 vm::CallResult<std::vector<std::u16string>> getCanonicalLocales(
     vm::Runtime &runtime,
     const std::vector<std::u16string> &locales) {
@@ -33,7 +34,7 @@ vm::CallResult<std::vector<std::u16string>> getCanonicalLocales(
   }
   return canonicalLocales;
 }
-
+*/
 // https://402.ecma-international.org/8.0/#sec-bestavailablelocale
 std::optional<std::u16string> bestAvailableLocale(
     const std::vector<std::u16string> &availableLocales,

--- a/unittests/PlatformIntl/CMakeLists.txt
+++ b/unittests/PlatformIntl/CMakeLists.txt
@@ -13,6 +13,5 @@ if(${HERMES_ENABLE_INTL})
 
   # target_link_libraries(PlatformIntlTests hermesapi)
 endif()
-
-add_hermes_unittest(BCP47ParserTests BCP47ParserTest.cpp)
-target_link_libraries(BCP47ParserTests hermesBCP47Parser)
+  add_hermes_unittest(BCP47ParserTests BCP47ParserTest.cpp)
+  target_link_libraries(BCP47ParserTests hermesBCP47Parser)


### PR DESCRIPTION
## Summary

synchronize Internationalization code on Hermes-windows with Hermes-Meta.
Have commented out the few files in [lib/Platform/Intl/CMakeLists.txt], failing due to Intl not enabled in Hermes, which will be fixed in future Prs.

## Test Plan
     Ran the Unit tests, its successful.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/228)