### PR TITLE
Use /O1 for Release only

### DIFF
--- a/API/hermes_shared/CMakeLists.txt
+++ b/API/hermes_shared/CMakeLists.txt
@@ -53,9 +53,6 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
   # Generate PDBs
   set(compile_flags "${compile_flags} /Zi")
 
-  # Temporary avoid the optimization for speed since VS 17.14.0 has auto-vectorization issues.
-  set(compile_flags "${compile_flags} /O1")
-
   set(link_flags_debug "/DEBUG")
 
   # Use /OPT:NOICF because hermes associates function pointer with its name.
@@ -76,3 +73,9 @@ set_target_properties(libshared PROPERTIES
   # To make sure that the resulting DLL name is hermes.dll
   OUTPUT_NAME hermes
 )
+
+if (MSVC)
+  # Temporary avoid the auto-vectorization optimization since VS 17.14.0 produces incorrect code.
+  # Set /O1 only for Release configs using modern CMake target_compile_options.
+  target_compile_options(libshared PRIVATE $<$<CONFIG:Release>:/O1>)
+endif()

--- a/cmake/modules/Hermes.cmake
+++ b/cmake/modules/Hermes.cmake
@@ -94,9 +94,6 @@ function(hermes_update_compile_flags name)
     
     # Ensure debug symbols are generated for all sources.
     set(flags "${flags} /Zi")
-
-    # Temporary avoid the optimization for speed since VS 17.14.0 has auto-vectorization issues.
-    set(flags "${flags} /O1")
   #endif ()
 
   if (NOT HERMES_ENABLE_EH_RTTI)
@@ -119,6 +116,12 @@ function(hermes_update_compile_flags name)
     # Update target props, since all sources are C++.
     set_property(TARGET ${name} APPEND_STRING PROPERTY
       COMPILE_FLAGS "${flags}")
+  endif ()
+
+  if (MSVC)
+    # Temporary avoid the auto-vectorization optimization since VS 17.14.0 produces incorrect code.
+    # Set /O1 only for Release configs using modern CMake target_compile_options.
+    target_compile_options(${name} PRIVATE $<$<CONFIG:Release>:/O1>)
   endif ()
 endfunction()
 


### PR DESCRIPTION
PR #219 had worked around the MSVC compiler issues with auto-vectorization by replacing /O2 with /O1.
The issue is that the change was applied to all configurations and causes the Debug build to fail.
In this PR we address this issue by applying the /O1 flag only to the Release configuration.