### PR TITLE
Remove edits from hermes.cpp

### DIFF
--- a/API/hermes_shared/inspector/react-native-0.72/ReactCommon/hermes/inspector/chrome/Connection.cpp
+++ b/API/hermes_shared/inspector/react-native-0.72/ReactCommon/hermes/inspector/chrome/Connection.cpp
@@ -735,11 +735,15 @@ void Connection::Impl::handle(
       .thenError<std::exception>(sendErrorToClient(req.id));
 }
 
+static facebook::hermes::IHermesRootAPI* getHermesRootAPI() {
+  // The makeHermesRootAPI returns a singleton.
+  return facebook::jsi::castInterface<facebook::hermes::IHermesRootAPI>(
+      facebook::hermes::makeHermesRootAPI());
+}
+
 void Connection::Impl::handle(const m::profiler::StartRequest &req) {
   runInExecutor(req.id, [this, id = req.id]() {
-    auto *hermesRootAPI = facebook::jsi::castInterface<facebook::hermes::IHermesRootAPI>(
-        facebook::hermes::makeHermesRootAPI());
-    hermesRootAPI->enableSamplingProfiler();
+    getHermesRootAPI()->enableSamplingProfiler();
     sendResponseToClient(m::makeOkResponse(id));
   });
 }
@@ -748,9 +752,7 @@ void Connection::Impl::handle(const m::profiler::StopRequest &req) {
   HermesRuntime *hermesRT = &getRuntime();
 
   runInExecutor(req.id, [this, id = req.id, hermesRT]() {
-    auto *hermesRootAPI = facebook::jsi::castInterface<facebook::hermes::IHermesRootAPI>(
-        facebook::hermes::makeHermesRootAPI());
-    hermesRootAPI->disableSamplingProfiler();
+    getHermesRootAPI()->disableSamplingProfiler();
 
     std::ostringstream profileStream;
     // HermesRuntime instance methods are usually unsafe to be called with a


### PR DESCRIPTION
This PR removes all `hermes-windows` repo changes from the `API\hermes\hermes.cpp` file that implements Hermes JSI.
After this PR is merged the `hermes.cpp` will be the same as in the `facebook\hermes` upstream repo.

PR has the following changes:
- Removed all the remaining JSI versioning code from `hermes.cpp`.
- Moved the `getVMRuntime` method to the `hermes_win.cpp` file where it is used.
- Reduced the code duplication with the `makeHermesRootAPI` calls by wrapping them into `getHermesRootAPI` function. The `getHermesRootAPI` should make it more visible that it is actually a call to get a singleton and not creating a new root API on every call.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/243)