### PR TITLE
Enable local execution of JS regression tests

### DIFF
--- a/.ado/scripts/bash-alias/python3
+++ b/.ado/scripts/bash-alias/python3
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# This is a wrapper script to make 'python3' available in bash environments.
+# It calls the real python.exe with all the arguments passed to this script.
+#
+
+"python.exe" "$@"

--- a/.ado/scripts/package-lock.json
+++ b/.ado/scripts/package-lock.json
@@ -144,9 +144,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
## Description

This pull request updates the build script to allow developers to run the JavaScript regression tests (`--jstest`) locally.

### The Problem

Previously, the JavaScript regression tests could only be run in the CI environment. Attempting to run them on a local Windows machine was not supported due to two main issues:

1.  **Environment Setup:** The test runner (LIT) requires specific tools like Git Bash and Python to be available in the `PATH`.
2.  **Bash Sub-shell Context:** The LIT framework runs tests inside a `bash` sub-shell, which did not correctly locate the `python3` command from the parent Windows environment, causing `command not found` errors.

This prevented developers from debugging JS tests on their local machines.

### The Solution

This PR modifies the `.ado/scripts/build.js` script to configure the necessary environment for the tests automatically. The changes include:

1.  **`setupJSTestEnvPaths()` Function:** A new function is called before the `--jstest` step to prepare the environment by modifying the `PATH`.

2.  **Dynamic Path Discovery:** The script now uses the `where` utility to find `git.exe` and `python.exe` dynamically, removing the need for hardcoded paths.

3.  **`python3` Wrapper Script:** A `bash` script located at `.ado/scripts/bash-alias/python3` acts as a wrapper that calls the real `python.exe`. This ensures the `python3` command is available inside the LIT test environment.

As a result, developers can now run the JS tests locally with a single command, without needing to perform any manual environment setup.

## How to Verify

1.  Ensure `git` and `python` are available in your system's PATH.
2.  From the root of the repository, run the following command in a standard PowerShell or Command Prompt window:
    ```powershell
    node .\.ado\scripts\build.js --jstest
    ```
3.  The build should proceed, and the JS regression tests should execute without errors related to finding `python3`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/251)