### PR TITLE
Improve Node-API scope management

### DIFF
--- a/API/hermes_node_api_jsi/NodeApiJsiRuntime.cpp
+++ b/API/hermes_node_api_jsi/NodeApiJsiRuntime.cpp
@@ -2186,6 +2186,7 @@ void NodeApiJsiRuntime::NodeApiRefCountedPointerValue::deleteStackValue(
   CHECK_ELSE_CRASH(value_, "value_ must not be null");
   if (canBeDeletedFromStack_) {
     delete this;
+    return;
   }
 
   if (usedByJsiPointer() && ref_ == nullptr) {


### PR DESCRIPTION
The key changes in this PR are:
- Implemented pre- and post-condition checks for all Node-API functions.
- Addressed some outstanding TODO items.
- Started to reduce the API surface in the `hermes_node_api.h`
- Removed handing of unhandled promise rejections. They are not needed for unit tests and were adding unnecessary complexity on Node-API environment initialization.
- Merged changes from node-api-jsi repo (PR: https://github.com/microsoft/node-api-jsi/pull/13) to the `NodeApiJsiRuntime.cpp` to fix a memory corruption issues.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/254)