### PR TITLE
Fix SDL pipeline failures for ESLint

### DIFF
--- a/.ado/build-template.yml
+++ b/.ado/build-template.yml
@@ -72,11 +72,12 @@ extends:
       componentgovernance:
         ignoreDirectories: $(Build.SourcesDirectory)\website
       eslint:
-        enableExclusions: true
-        # This repo does not ship any JavaScript code. But it has many test cases for
-        # the Hermes JS engine that fail parsing, have code considered insecure and crash eslint.
-        exclusionPatterns: |
-          '**/*.*'
+        # This repo does not ship any JavaScript code. But it has many test cases
+        # for the Hermes JS engine that fail parsing, have code considered
+        # insecure, and crash ESLint. Exclusions are in .eslintignore at the
+        # repo root. Do NOT use exclusionPatterns: '**/*.*' here because ESLint
+        # errors when all files matching the glob are ignored.
+        enableExclusions: false
       suppression:
         suppressionFile: $(Build.SourcesDirectory)\.ado\guardian\SDL\.gdnsuppress
       codeql:

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,13 @@
+# This repo does not ship any JavaScript code. All JS/TS files here are
+# test cases, benchmarks, third-party tools, or internal polyfills for the
+# Hermes JS engine. Exclude them from ESLint security scanning to avoid
+# false positives on patterns like eval() and new Function() that are
+# intentionally used in engine test cases.
+benchmarks/
+examples/
+external/
+lib/
+test/
+tools/
+unittests/
+utils/


### PR DESCRIPTION
## The issue

The SDL (Security Development Lifecycle) ESLint checks fail in two different pipelines:

### CI/PR Pipeline (`build-template.yml`)

The Guardian ESLint task was configured with `exclusionPatterns: '**/*.*'` which
translates to `--ignore-pattern **/*.*`. This ignores ALL files. ESLint 7 treats
"all files matching the glob are ignored" as a fatal error (exit code 2):

```
You are linting "D:\a\_work\1\s/**/*.{js,ts,jsx,tsx}", but all of the files
matching the glob pattern "D:\a\_work\1\s/**/*.{js,ts,jsx,tsx}" are ignored.
```

### Release Pipeline (via `Office.Official.PipelineTemplate.yml`)

The release pipeline extends the Official 1ES template without any `sdl:`
configuration. The template runs ESLint with defaults (no exclusions), so ESLint
scans all JS files and finds violations in non-shipped code:

- `benchmarks/octane/*.js` — `no-eval`, `no-implied-eval`, `no-new-func`
  (third-party Octane benchmark suite)
- `test/**/*.js` — `no-eval`, `no-new-func`
  (intentional test cases for the Hermes JS engine)
- `tools/**/*.js` — various violations
  (hermes-parser tooling, not shipped)
- `utils/*.js` — `no-eval`
  (utility scripts)

Additionally, the 48 baseline entries in `guardian_baselines.gdnbaselines`
(created 2025-02-25, 180-day expiry) have expired, so previously suppressed
violations now surface as errors.

## Root Cause

This repo does not ship any JavaScript code. All JS/TS files are test cases,
benchmarks, third-party tools, or internal polyfills for the Hermes JS engine.
These files intentionally use patterns like `eval()` and `new Function()` that
SDL security rules flag.

## Solution

### 1. Created `.eslintignore` at repo root

Standard ESLint mechanism to exclude directories from linting. ESLint reads this
file automatically regardless of pipeline configuration (not affected by
`--no-eslintrc`). Excludes:

- `benchmarks/` — third-party benchmark suites (Octane, etc.)
- `examples/` — example code
- `external/` — external dependencies
- `lib/` — internal JS polyfills compiled into the VM
- `test/` — engine test cases (1,613 JS files)
- `tools/` — hermes-parser and other tooling
- `unittests/` — C++ unit test fixtures
- `utils/` — utility scripts

Leaves `.ado/scripts/*.js` (build.js, setVersionNumber.js) as lintable — these
are simple Node.js build scripts that don't use `eval()` or other patterns
flagged by SDL rules.

### 2. Updated `.ado/build-template.yml`

Changed the `eslint` SDL config from:

```yaml
eslint:
  enableExclusions: true
  exclusionPatterns: |
    '**/*.*'
```

to:

```yaml
eslint:
  enableExclusions: false
```

This removes the `--ignore-pattern **/*.*` flag that caused ESLint to error.
Exclusions are now handled by `.eslintignore` instead.

### Why no changes to `release-pipeline.yml`

The `.eslintignore` file is read by ESLint from the source directory
automatically. The Official 1ES template checks out the repo source, so the
`.eslintignore` file applies to the release pipeline without any YAML changes.

## Files Changed

| File | Change |
|------|--------|
| `.eslintignore` | **New** — excludes non-shipped JS directories |
| `.ado/build-template.yml` | Removed broken `exclusionPatterns: '**/*.*'`, set `enableExclusions: false` |

## Testing

- CI/PR pipeline: ESLint should no longer error with "all files are ignored"
- Release pipeline: ESLint should no longer find violations in excluded directories
- `.ado/scripts/*.js` remain lintable as a sanity check (simple Node.js build scripts)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/270)