### PR TITLE
Fix benchmark workflow build breaks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,10 +41,10 @@ jobs:
         if: always()
         shell: bash
         run: |
-          mkdir -p .benchmark-results
-          cp -f benchmarks/hermes-windows/bench_report.md .benchmark-results/ 2>/dev/null || true
+          mkdir -p benchmark-results
+          cp -f benchmarks/hermes-windows/bench_report.md benchmark-results/ 2>/dev/null || true
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "${{ github.event.pull_request.number }}" > .benchmark-results/pr-number.txt
+            echo "${{ github.event.pull_request.number }}" > benchmark-results/pr-number.txt
           fi
 
       - name: Upload results
@@ -52,5 +52,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
-          path: .benchmark-results/
+          path: benchmark-results/
           retention-days: 30

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           MSYS2_ARG_CONV_EXCL: "*"
         run: |
-          cmake -S . -B build -G "Visual Studio 17 2022" \
+          cmake -S . -B build -G "Visual Studio 17 2022" -T ClangCL \
             -DCMAKE_SYSTEM_NAME=Windows \
             -DCMAKE_SYSTEM_VERSION=10.0.15063 \
             -DCMAKE_SYSTEM_PROCESSOR=x86_64

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,24 +24,18 @@ jobs:
       - uses: ./.github/actions/setup-node
 
       - name: Build hermes (x64 Release)
-        shell: bash
-        env:
-          MSYS2_ARG_CONV_EXCL: "*"
+        shell: cmd
         run: |
-          cmake -S . -B build -G "Visual Studio 17 2022" -T ClangCL \
-            -DCMAKE_SYSTEM_NAME=Windows \
-            -DCMAKE_SYSTEM_VERSION=10.0.15063 \
-            -DCMAKE_SYSTEM_PROCESSOR=x86_64
-
-          cmake --build build --config Release --target hermes -- \
-            -m /p:UseMultiToolTask=true /p:EnforceProcessCountAcrossBuilds=true
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          cmake --preset=ninja-clang-release
+          cmake --build build/ninja-clang-release --target hermes
 
       - name: Run benchmarks
         shell: bash
         run: |
           node --experimental-strip-types \
             benchmarks/hermes-windows/bench_and_report.ts \
-            --binary build/bin/Release/hermes.exe
+            --binary build/ninja-clang-release/bin/hermes.exe
 
       - name: Stage results
         if: always()

--- a/benchmarks/bench-runner/runner.py
+++ b/benchmarks/bench-runner/runner.py
@@ -43,7 +43,11 @@ def collectorHeapSize(peakSize):
 
 
 def displayFilePath(file):
-    relpath = os.path.relpath(file)
+    try:
+        relpath = os.path.relpath(file)
+    except ValueError:
+        # relpath fails on Windows when file and cwd are on different drives
+        return os.path.abspath(file)
     abspath = os.path.abspath(file)
     return relpath if len(relpath) < len(abspath) else abspath
 


### PR DESCRIPTION
## Summary

Need to force the clang frontend for building this repo.
The new `Benchmark` workflow is optional so it does not affect other people's PR from working.

## Test Plan

See if the new workflow can be picked up in this PR CI directly.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/307)