### PR TITLE
Node-API - enable internal fields in frozen objects

### DIFF
--- a/API/hermes_node_api/hermes_node_api.cpp
+++ b/API/hermes_node_api/hermes_node_api.cpp
@@ -1012,7 +1012,9 @@ class NodeApiEnvironment {
       vm::SymbolID name,
       vm::DefinePropertyFlags dpFlags,
       vm::Handle<> valueOrAccessor,
-      bool *result) noexcept;
+      bool *result,
+      vm::PropOpFlags opFlags =
+          vm::PropOpFlags().plusThrowOnError()) noexcept;
 
   //---------------------------------------------------------------------------
   // Methods to work with external data objects
@@ -3549,14 +3551,15 @@ napi_status NodeApiEnvironment::defineOwnProperty(
     vm::SymbolID name,
     vm::DefinePropertyFlags dpFlags,
     vm::Handle<> valueOrAccessor,
-    bool *result) noexcept {
+    bool *result,
+    vm::PropOpFlags opFlags) noexcept {
   vm::CallResult<bool> cr = vm::JSObject::defineOwnProperty(
       object,
       runtime_,
       name,
       dpFlags,
       valueOrAccessor,
-      vm::PropOpFlags().plusThrowOnError());
+      opFlags);
   CHECK_STATUS(checkExecutionStatus(cr.getStatus()));
   if (result != nullptr) {
     *result = *cr;
@@ -3674,7 +3677,8 @@ napi_status NodeApiEnvironment::getExternalPropertyValue(
         getPredefinedSymbol(NodeApiPredefined::napi_externalValue),
         vm::DefinePropertyFlags::getNewNonEnumerableFlags(),
         decoratedObj,
-        nullptr));
+        nullptr,
+        vm::PropOpFlags().plusInternalForce()));
   }
   *result = externalValue;
   return clearLastNativeError();
@@ -6219,7 +6223,8 @@ napi_status NAPI_CDECL napi_type_tag_object(
       env->getPredefinedSymbol(NodeApiPredefined::napi_typeTag),
       vm::DefinePropertyFlags::getNewNonEnumerableFlags(),
       asHandle(tagBuffer),
-      nullptr);
+      nullptr,
+      vm::PropOpFlags().plusInternalForce());
 }
 
 // TODO: match Node.js code for tags


### PR DESCRIPTION
## Summary

Fix `TypeError: Cannot add new property 'node_api.externalValue.<guid>'` when Node-API functions are used on frozen or sealed JavaScript objects.

The Hermes Node-API implementation attaches hidden bookkeeping symbol properties to user JS objects in two places:

- `getExternalPropertyValue()` adds a `node_api.externalValue.<guid>` symbol — used to hang native data and finalizers off an object (`napi_wrap`, `napi_add_finalizer`, `napi_create_external`, etc.).
- `napi_type_tag_object()` adds a `node_api.typeTag.<guid>` symbol to record the type tag.

Both paths went through `NodeApiEnvironment::defineOwnProperty()`, which called `vm::JSObject::defineOwnProperty()` with `PropOpFlags().plusThrowOnError()` but *without* `InternalForce`. When the target object was non-extensible (for example, frozen by React Native's `deepFreezeAndThrowOnMutationInDev.js` in dev builds), `JSObject::addOwnProperty` rejected the addition:

```
TypeError: Cannot add new property 'node_api.externalValue.735e14c9-354f-489b-9f27-02acbc090975'
```

These are *internal* Node-API bookkeeping properties, not user-visible properties, so they should be addable regardless of the object's extensibility state. Hermes already has the `PropOpFlags::InternalForce` flag for exactly this purpose — `JSArrayBuffer::setExternalFinalizer` uses the same pattern for its own internal finalizer property.

### Changes in `API/hermes_node_api/hermes_node_api.cpp`

1. Added an optional `vm::PropOpFlags opFlags` parameter (defaulting to `PropOpFlags().plusThrowOnError()`) to `NodeApiEnvironment::defineOwnProperty()` so callers that need `InternalForce` can opt in while existing callers are unaffected.
2. `getExternalPropertyValue()` now passes `PropOpFlags().plusInternalForce()` when adding the `napi_externalValue` symbol.
3. `napi_type_tag_object()` now passes `PropOpFlags().plusInternalForce()` when adding the `napi_typeTag` symbol.

The user-facing `napi_define_properties` callers (which legitimately must fail on frozen objects per the Node-API contract) keep the default `ThrowOnError` behavior.

## Test Plan

- **Repro (before fix):** In react-native-windows, build and run `packages/playground/windows/playground-composition.sln`. The Metro console shows the following repeated errors during startup, preventing the app from rendering:
  ```
  ERROR  [TypeError: Cannot add new property 'node_api.externalValue.735e14c9-354f-489b-9f27-02acbc090975']
  ```
- **After fix:** Rebuilt `hermes.dll` with the change and consumed it from the RNW playground. The playground-composition app starts, loads `Samples/rntester.tsx` and `Samples/click.tsx` bundles, and renders without the `TypeError`.
- Existing Hermes Node-API unit tests continue to pass (no user-facing `defineOwnProperty` callers changed behavior — the default `PropOpFlags` remain `plusThrowOnError()` only).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/311)