### PR TITLE
Make benchmark report foldable

### DIFF
--- a/benchmarks/hermes-windows/2026-3-24-compare.md
+++ b/benchmarks/hermes-windows/2026-3-24-compare.md
@@ -2,6 +2,8 @@
 
 **Total benchmarks:** 102
 
+**Runtimes:** hermes (test), shermes (test)
+
 <details>
 <summary><h3>v8 (3256ms, 3027ms)</h3></summary>
 

--- a/benchmarks/hermes-windows/2026-3-24-compare.md
+++ b/benchmarks/hermes-windows/2026-3-24-compare.md
@@ -2,7 +2,7 @@
 
 **Total benchmarks:** 102
 
-**Runtimes:** hermes (test), shermes (test)
+**Inputs:** 2026-3-24.json, 2026-3-25-static.json
 
 <details>
 <summary><strong>v8 (3256ms, 3027ms)</strong></summary>

--- a/benchmarks/hermes-windows/2026-3-24-compare.md
+++ b/benchmarks/hermes-windows/2026-3-24-compare.md
@@ -2,164 +2,200 @@
 
 **Total benchmarks:** 102
 
-## v8
+<details>
+<summary><h2>v8 (3256ms, 3027ms)</h2></summary>
 
-| Benchmark (ms) | hermes (test) | shermes (test) |
+| v8 | hermes (test) | shermes (test) |
 |---|---:|---:|
-| v8-crypto | 592.5 | **439.5** |
-| v8-deltablue | 751.5 | **686.5** |
-| v8-raytrace | 122 | **92** |
-| v8-regexp | **597** | 744.5 |
-| v8-richards | 975 | **869.5** |
-| v8-splay | 218 | **195** |
+| v8-crypto | 592.5ms | **439.5ms** |
+| v8-deltablue | 751.5ms | **686.5ms** |
+| v8-raytrace | 122ms | **92ms** |
+| v8-regexp | **597ms** | 744.5ms |
+| v8-richards | 975ms | **869.5ms** |
+| v8-splay | 218ms | **195ms** |
 
-## test-suites
+</details>
 
-| Benchmark (ms) | hermes (test) | shermes (test) |
+<details>
+<summary><h2>test-suites (169855.5ms, 136013ms)</h2></summary>
+
+| test-suites | hermes (test) | shermes (test) |
 |---|---:|---:|
-| box2d | 2555.5 | **1759** |
-| earley-boyer | 2377 | **1816** |
-| navier-stokes | 4314 | **3430** |
-| pdfjs | 936 | **791** |
-| gbemu | 2191.5 | **1776.5** |
-| code-load | 4503.5 | **4154.5** |
-| typescript | 3317.5 | **2669.5** |
-| simpleSum | 5630 | **935** |
-| propAccess | **2188.5** | 2300.5 |
-| allocObj | 191 | **0.5** |
-| allocObjLit | 6123 | **4240** |
-| allocNewObj | 19273 | **15494** |
-| allocArray | 191.5 | **0** |
-| allocNewArray | 35283 | **28287** |
-| arrayRead | 84.5 | **70** |
-| arrayReadByIndex | 603.5 | **452.5** |
-| largeArrayRead | **526** | 550.5 |
-| arrayWrite | 239 | **174** |
-| largeArrayWrite | 2151.5 | **1601** |
-| interp-dispatch | 1920 | **1905** |
-| wb-perf | 9493 | **8964** |
-| arrayReverse | 40.5 | **39.5** |
-| arrayMap | 1474 | **971.5** |
-| arrayIndexOf | 145 | **138** |
-| arrayLastIndexOf | 145.5 | **140.5** |
-| arrayEvery | 2214.5 | **1401.5** |
-| arraySome | 2213 | **1403.5** |
-| arrayFill | 2410 | **1989.5** |
-| arrayFilter | 1838.5 | **1056.5** |
-| arrayFind | 3286 | **2258** |
-| arrayFindIndex | 3330.5 | **2332** |
-| arrayPop | 1049 | **934** |
-| arrayReduce | 2065.5 | **1318** |
-| arrayReduceRight | 2090 | **1309.5** |
-| arrayShift | 2093 | **1524** |
-| arrayUnshift | 2102.5 | **1576** |
-| arrayIncludes | 1189 | **957.5** |
-| arrayFrom | 1123.5 | **1036.5** |
-| arrayCopyWithin | 1498 | **1111.5** |
-| stringFromCharCode | 90 | **77** |
-| arraySlice | 787 | **573** |
-| arraySplice | 27 | **26.5** |
-| arrayOf | 1028 | **871.5** |
-| stringCharAt | 1255.5 | **1090** |
-| stringMatch | 2834 | **2253** |
-| stringSearch | 2843.5 | **2246** |
-| stringStartsWith | 558 | **452** |
-| stringEndsWith | 529.5 | **449.5** |
-| stringIncludes | 2041.5 | **1663** |
-| stringIndexOf | **1461.5** | 1681 |
-| stringLastIndexOf | **1946** | 2197 |
-| stringSplit | 790 | **656.5** |
-| stringSlice | 481 | **419** |
-| stringPadStart | 2898 | **2276** |
-| stringPadEnd | 2898.5 | **2282** |
-| regExpMatch | **1507** | 1544.5 |
-| regExpSearch | **1210** | 1214.5 |
-| regExpToString | 1045.5 | **1005** |
-| stringReplace | **1490** | 1509.5 |
-| regExpReplace | 871 | **833.5** |
-| regExpFlags | 943 | **833.5** |
-| regExpSplit | 1240.5 | **1192** |
-| numberArrayReadWrite | 2325 | **2078** |
-| protoCache | **2354** | 3721.5 |
+| box2d | 2555.5ms | **1759ms** |
+| earley-boyer | 2377ms | **1816ms** |
+| navier-stokes | 4314ms | **3430ms** |
+| pdfjs | 936ms | **791ms** |
+| gbemu | 2191.5ms | **1776.5ms** |
+| code-load | 4503.5ms | **4154.5ms** |
+| typescript | 3317.5ms | **2669.5ms** |
+| simpleSum | 5630ms | **935ms** |
+| propAccess | **2188.5ms** | 2300.5ms |
+| allocObj | 191ms | **0.5ms** |
+| allocObjLit | 6123ms | **4240ms** |
+| allocNewObj | 19273ms | **15494ms** |
+| allocArray | 191.5ms | **0ms** |
+| allocNewArray | 35283ms | **28287ms** |
+| arrayRead | 84.5ms | **70ms** |
+| arrayReadByIndex | 603.5ms | **452.5ms** |
+| largeArrayRead | **526ms** | 550.5ms |
+| arrayWrite | 239ms | **174ms** |
+| largeArrayWrite | 2151.5ms | **1601ms** |
+| interp-dispatch | 1920ms | **1905ms** |
+| wb-perf | 9493ms | **8964ms** |
+| arrayReverse | 40.5ms | **39.5ms** |
+| arrayMap | 1474ms | **971.5ms** |
+| arrayIndexOf | 145ms | **138ms** |
+| arrayLastIndexOf | 145.5ms | **140.5ms** |
+| arrayEvery | 2214.5ms | **1401.5ms** |
+| arraySome | 2213ms | **1403.5ms** |
+| arrayFill | 2410ms | **1989.5ms** |
+| arrayFilter | 1838.5ms | **1056.5ms** |
+| arrayFind | 3286ms | **2258ms** |
+| arrayFindIndex | 3330.5ms | **2332ms** |
+| arrayPop | 1049ms | **934ms** |
+| arrayReduce | 2065.5ms | **1318ms** |
+| arrayReduceRight | 2090ms | **1309.5ms** |
+| arrayShift | 2093ms | **1524ms** |
+| arrayUnshift | 2102.5ms | **1576ms** |
+| arrayIncludes | 1189ms | **957.5ms** |
+| arrayFrom | 1123.5ms | **1036.5ms** |
+| arrayCopyWithin | 1498ms | **1111.5ms** |
+| stringFromCharCode | 90ms | **77ms** |
+| arraySlice | 787ms | **573ms** |
+| arraySplice | 27ms | **26.5ms** |
+| arrayOf | 1028ms | **871.5ms** |
+| stringCharAt | 1255.5ms | **1090ms** |
+| stringMatch | 2834ms | **2253ms** |
+| stringSearch | 2843.5ms | **2246ms** |
+| stringStartsWith | 558ms | **452ms** |
+| stringEndsWith | 529.5ms | **449.5ms** |
+| stringIncludes | 2041.5ms | **1663ms** |
+| stringIndexOf | **1461.5ms** | 1681ms |
+| stringLastIndexOf | **1946ms** | 2197ms |
+| stringSplit | 790ms | **656.5ms** |
+| stringSlice | 481ms | **419ms** |
+| stringPadStart | 2898ms | **2276ms** |
+| stringPadEnd | 2898.5ms | **2282ms** |
+| regExpMatch | **1507ms** | 1544.5ms |
+| regExpSearch | **1210ms** | 1214.5ms |
+| regExpToString | 1045.5ms | **1005ms** |
+| stringReplace | **1490ms** | 1509.5ms |
+| regExpReplace | 871ms | **833.5ms** |
+| regExpFlags | 943ms | **833.5ms** |
+| regExpSplit | 1240.5ms | **1192ms** |
+| numberArrayReadWrite | 2325ms | **2078ms** |
+| protoCache | **2354ms** | 3721.5ms |
 
-## micros
+</details>
 
-| Benchmark (ms) | hermes (test) | shermes (test) |
+<details>
+<summary><h2>micros (31667ms, 30430ms)</h2></summary>
+
+| micros | hermes (test) | shermes (test) |
 |---|---:|---:|
-| micros/getNodeById.js | 4779.5 | **3997** |
-| micros/setInsert.js | 2657 | **2442.5** |
-| micros/stringify-number.js | 1772.5 | **1508.5** |
-| micros/typed-array-sort.js | **22458** | 22482 |
+| getNodeById.js | 4779.5ms | **3997ms** |
+| setInsert.js | 2657ms | **2442.5ms** |
+| stringify-number.js | 1772.5ms | **1508.5ms** |
+| typed-array-sort.js | **22458ms** | 22482ms |
 
-## jit-benches
+</details>
 
-| Benchmark (ms) | hermes (test) | shermes (test) |
+<details>
+<summary><h2>jit-benches (3940ms, 2292ms)</h2></summary>
+
+| jit-benches | hermes (test) | shermes (test) |
 |---|---:|---:|
-| jit-benches/idisp.js | 1927 | **1905.5** |
-| jit-benches/idispn.js | 2013 | **386.5** |
+| idisp.js | 1927ms | **1905.5ms** |
+| idispn.js | 2013ms | **386.5ms** |
 
-## many-subclasses
+</details>
 
-| Benchmark (ms) | hermes (test) | shermes (test) |
+<details>
+<summary><h2>many-subclasses (50392ms, 25202ms)</h2></summary>
+
+| many-subclasses | hermes (test) | shermes (test) |
 |---|---:|---:|
-| many-subclasses/many.js | 18218 | **15805.5** |
-| many-subclasses/many-sh-1.js | 8153.5 | **2262** |
-| many-subclasses/many-sh-2.js | 8067.5 | **2460.5** |
-| many-subclasses/many-sh-3.js | 7975 | **2331** |
-| many-subclasses/many-sh-4.js | 7978 | **2343** |
+| many.js | 18218ms | **15805.5ms** |
+| many-sh-1.js | 8153.5ms | **2262ms** |
+| many-sh-2.js | 8067.5ms | **2460.5ms** |
+| many-sh-3.js | 7975ms | **2331ms** |
+| many-sh-4.js | 7978ms | **2343ms** |
 
-## map-objects
+</details>
 
-| Benchmark (ms) | hermes (test) | shermes (test) |
+<details>
+<summary><h2>map-objects (1924ms, 1641.5ms)</h2></summary>
+
+| map-objects | hermes (test) | shermes (test) |
 |---|---:|---:|
-| map-objects/map-objects-untyped.js | 993 | **921.5** |
-| map-objects/map-objects-typed.js | 931 | **720** |
+| map-objects-untyped.js | 993ms | **921.5ms** |
+| map-objects-typed.js | 931ms | **720ms** |
 
-## map-strings
+</details>
 
-| Benchmark (ms) | hermes (test) | shermes (test) |
+<details>
+<summary><h2>map-strings (2247.5ms, 2037ms)</h2></summary>
+
+| map-strings | hermes (test) | shermes (test) |
 |---|---:|---:|
-| map-strings/map-strings-untyped.js | 1163.5 | **1107.5** |
-| map-strings/map-strings-typed.js | 1084 | **929.5** |
+| map-strings-untyped.js | 1163.5ms | **1107.5ms** |
+| map-strings-typed.js | 1084ms | **929.5ms** |
 
-## nbody
+</details>
 
-| Benchmark (ms) | hermes (test) | shermes (test) |
+<details>
+<summary><h2>nbody (2009.5ms, 5046ms)</h2></summary>
+
+| nbody | hermes (test) | shermes (test) |
 |---|---:|---:|
-| nbody/original/nbody.js | **704** | 1656 |
-| nbody/fully-typed/nbody.js | **615.5** | 1722.5 |
-| nbody/fully-typed/nbody.ts | **690** | 1667.5 |
+| original/nbody.js | **704ms** | 1656ms |
+| fully-typed/nbody.js | **615.5ms** | 1722.5ms |
+| fully-typed/nbody.ts | **690ms** | 1667.5ms |
 
-## string-switch
+</details>
 
-| Benchmark (ms) | hermes (test) | shermes (test) |
+<details>
+<summary><h2>string-switch (1321ms, 6229ms)</h2></summary>
+
+| string-switch (string-switch/plain) | hermes (test) | shermes (test) |
 |---|---:|---:|
-| string-switch/plain/bench.js | **1321** | 6229 |
+| bench.js | **1321ms** | 6229ms |
 
-## raytracer
+</details>
 
-| Benchmark (ms) | hermes (test) | shermes (test) |
+<details>
+<summary><h2>raytracer (2964.5ms, 2394.5ms)</h2></summary>
+
+| raytracer (raytracer/original) | hermes (test) | shermes (test) |
 |---|---:|---:|
-| raytracer/original/bench-raytracer.js | 1426.5 | **1190** |
-| raytracer/original/raytracer.ts | 1538 | **1204.5** |
+| bench-raytracer.js | 1426.5ms | **1190ms** |
+| raytracer.ts | 1538ms | **1204.5ms** |
 
-## MiniReact
+</details>
 
-| Benchmark (ms) | hermes (test) | shermes (test) |
+<details>
+<summary><h2>MiniReact (16022.5ms, 18818ms)</h2></summary>
+
+| MiniReact | hermes (test) | shermes (test) |
 |---|---:|---:|
-| MiniReact/no-objects/out/simple-stripped.js | 2118 | **1693** |
-| MiniReact/no-objects/out/simple-lowered.js | 2151.5 | **1700.5** |
-| MiniReact/no-objects/out/music-stripped.js | **84.5** | 1187 |
-| MiniReact/no-objects/out/music-lowered.js | **90** | 1077.5 |
-| MiniReact/no-deps/stripped/MiniReact.js | **4699** | 5016 |
-| MiniReact/no-deps/MiniReact.js | **4651** | 5055.5 |
-| MiniReact/no-objects/out/simple.js | 2117.5 | **1666.5** |
-| MiniReact/no-objects/out/music.js | **111** | 1422 |
+| no-objects/out/simple-stripped.js | 2118ms | **1693ms** |
+| no-objects/out/simple-lowered.js | 2151.5ms | **1700.5ms** |
+| no-objects/out/music-stripped.js | **84.5ms** | 1187ms |
+| no-objects/out/music-lowered.js | **90ms** | 1077.5ms |
+| no-deps/stripped/MiniReact.js | **4699ms** | 5016ms |
+| no-deps/MiniReact.js | **4651ms** | 5055.5ms |
+| no-objects/out/simple.js | 2117.5ms | **1666.5ms** |
+| no-objects/out/music.js | **111ms** | 1422ms |
 
-## widgets
+</details>
 
-| Benchmark (ms) | hermes (test) | shermes (test) |
+<details>
+<summary><h2>widgets (6989ms, 5541.5ms)</h2></summary>
+
+| widgets | hermes (test) | shermes (test) |
 |---|---:|---:|
-| widgets/simple-classes/widgets.js | 1570 | **998.5** |
-| widgets/original/es5/widgets.js | 2713.5 | **2275.5** |
-| widgets/single-file/es5/widgets.js | 2705.5 | **2267.5** |
+| simple-classes/widgets.js | 1570ms | **998.5ms** |
+| original/es5/widgets.js | 2713.5ms | **2275.5ms** |
+| single-file/es5/widgets.js | 2705.5ms | **2267.5ms** |
+
+</details>

--- a/benchmarks/hermes-windows/2026-3-24-compare.md
+++ b/benchmarks/hermes-windows/2026-3-24-compare.md
@@ -3,7 +3,7 @@
 **Total benchmarks:** 102
 
 <details>
-<summary><h2>v8 (3256ms, 3027ms)</h2></summary>
+<summary><h3>v8 (3256ms, 3027ms)</h3></summary>
 
 | v8 | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -15,9 +15,8 @@
 | v8-splay | 218ms | **195ms** |
 
 </details>
-
 <details>
-<summary><h2>test-suites (169855.5ms, 136013ms)</h2></summary>
+<summary><h3>test-suites (169855.5ms, 136013ms)</h3></summary>
 
 | test-suites | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -87,9 +86,8 @@
 | protoCache | **2354ms** | 3721.5ms |
 
 </details>
-
 <details>
-<summary><h2>micros (31667ms, 30430ms)</h2></summary>
+<summary><h3>micros (31667ms, 30430ms)</h3></summary>
 
 | micros | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -99,9 +97,8 @@
 | typed-array-sort.js | **22458ms** | 22482ms |
 
 </details>
-
 <details>
-<summary><h2>jit-benches (3940ms, 2292ms)</h2></summary>
+<summary><h3>jit-benches (3940ms, 2292ms)</h3></summary>
 
 | jit-benches | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -109,9 +106,8 @@
 | idispn.js | 2013ms | **386.5ms** |
 
 </details>
-
 <details>
-<summary><h2>many-subclasses (50392ms, 25202ms)</h2></summary>
+<summary><h3>many-subclasses (50392ms, 25202ms)</h3></summary>
 
 | many-subclasses | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -122,9 +118,8 @@
 | many-sh-4.js | 7978ms | **2343ms** |
 
 </details>
-
 <details>
-<summary><h2>map-objects (1924ms, 1641.5ms)</h2></summary>
+<summary><h3>map-objects (1924ms, 1641.5ms)</h3></summary>
 
 | map-objects | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -132,9 +127,8 @@
 | map-objects-typed.js | 931ms | **720ms** |
 
 </details>
-
 <details>
-<summary><h2>map-strings (2247.5ms, 2037ms)</h2></summary>
+<summary><h3>map-strings (2247.5ms, 2037ms)</h3></summary>
 
 | map-strings | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -142,9 +136,8 @@
 | map-strings-typed.js | 1084ms | **929.5ms** |
 
 </details>
-
 <details>
-<summary><h2>nbody (2009.5ms, 5046ms)</h2></summary>
+<summary><h3>nbody (2009.5ms, 5046ms)</h3></summary>
 
 | nbody | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -153,18 +146,16 @@
 | fully-typed/nbody.ts | **690ms** | 1667.5ms |
 
 </details>
-
 <details>
-<summary><h2>string-switch (1321ms, 6229ms)</h2></summary>
+<summary><h3>string-switch (1321ms, 6229ms)</h3></summary>
 
 | string-switch (string-switch/plain) | hermes (test) | shermes (test) |
 |---|---:|---:|
 | bench.js | **1321ms** | 6229ms |
 
 </details>
-
 <details>
-<summary><h2>raytracer (2964.5ms, 2394.5ms)</h2></summary>
+<summary><h3>raytracer (2964.5ms, 2394.5ms)</h3></summary>
 
 | raytracer (raytracer/original) | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -172,9 +163,8 @@
 | raytracer.ts | 1538ms | **1204.5ms** |
 
 </details>
-
 <details>
-<summary><h2>MiniReact (16022.5ms, 18818ms)</h2></summary>
+<summary><h3>MiniReact (16022.5ms, 18818ms)</h3></summary>
 
 | MiniReact | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -188,9 +178,8 @@
 | no-objects/out/music.js | **111ms** | 1422ms |
 
 </details>
-
 <details>
-<summary><h2>widgets (6989ms, 5541.5ms)</h2></summary>
+<summary><h3>widgets (6989ms, 5541.5ms)</h3></summary>
 
 | widgets | hermes (test) | shermes (test) |
 |---|---:|---:|

--- a/benchmarks/hermes-windows/2026-3-24-compare.md
+++ b/benchmarks/hermes-windows/2026-3-24-compare.md
@@ -5,7 +5,7 @@
 **Runtimes:** hermes (test), shermes (test)
 
 <details>
-<summary><h3>v8 (3256ms, 3027ms)</h3></summary>
+<summary><strong>v8 (3256ms, 3027ms)</strong></summary>
 
 | v8 | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -18,7 +18,7 @@
 
 </details>
 <details>
-<summary><h3>test-suites (169855.5ms, 136013ms)</h3></summary>
+<summary><strong>test-suites (169855.5ms, 136013ms)</strong></summary>
 
 | test-suites | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -89,7 +89,7 @@
 
 </details>
 <details>
-<summary><h3>micros (31667ms, 30430ms)</h3></summary>
+<summary><strong>micros (31667ms, 30430ms)</strong></summary>
 
 | micros | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -100,7 +100,7 @@
 
 </details>
 <details>
-<summary><h3>jit-benches (3940ms, 2292ms)</h3></summary>
+<summary><strong>jit-benches (3940ms, 2292ms)</strong></summary>
 
 | jit-benches | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -109,7 +109,7 @@
 
 </details>
 <details>
-<summary><h3>many-subclasses (50392ms, 25202ms)</h3></summary>
+<summary><strong>many-subclasses (50392ms, 25202ms)</strong></summary>
 
 | many-subclasses | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -121,7 +121,7 @@
 
 </details>
 <details>
-<summary><h3>map-objects (1924ms, 1641.5ms)</h3></summary>
+<summary><strong>map-objects (1924ms, 1641.5ms)</strong></summary>
 
 | map-objects | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -130,7 +130,7 @@
 
 </details>
 <details>
-<summary><h3>map-strings (2247.5ms, 2037ms)</h3></summary>
+<summary><strong>map-strings (2247.5ms, 2037ms)</strong></summary>
 
 | map-strings | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -139,7 +139,7 @@
 
 </details>
 <details>
-<summary><h3>nbody (2009.5ms, 5046ms)</h3></summary>
+<summary><strong>nbody (2009.5ms, 5046ms)</strong></summary>
 
 | nbody | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -149,7 +149,7 @@
 
 </details>
 <details>
-<summary><h3>string-switch (1321ms, 6229ms)</h3></summary>
+<summary><strong>string-switch (1321ms, 6229ms)</strong></summary>
 
 | string-switch (string-switch/plain) | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -157,7 +157,7 @@
 
 </details>
 <details>
-<summary><h3>raytracer (2964.5ms, 2394.5ms)</h3></summary>
+<summary><strong>raytracer (2964.5ms, 2394.5ms)</strong></summary>
 
 | raytracer (raytracer/original) | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -166,7 +166,7 @@
 
 </details>
 <details>
-<summary><h3>MiniReact (16022.5ms, 18818ms)</h3></summary>
+<summary><strong>MiniReact (16022.5ms, 18818ms)</strong></summary>
 
 | MiniReact | hermes (test) | shermes (test) |
 |---|---:|---:|
@@ -181,7 +181,7 @@
 
 </details>
 <details>
-<summary><h3>widgets (6989ms, 5541.5ms)</h3></summary>
+<summary><strong>widgets (6989ms, 5541.5ms)</strong></summary>
 
 | widgets | hermes (test) | shermes (test) |
 |---|---:|---:|

--- a/benchmarks/hermes-windows/2026-3-24.md
+++ b/benchmarks/hermes-windows/2026-3-24.md
@@ -3,7 +3,7 @@
 **Total benchmarks:** 102
 
 <details>
-<summary><h2>v8 (3256ms)</h2></summary>
+<summary><h3>v8 (3256ms)</h3></summary>
 
 | v8 | hermes (test) |
 |---|---:|
@@ -15,9 +15,8 @@
 | v8-splay | 218ms |
 
 </details>
-
 <details>
-<summary><h2>test-suites (169855.5ms)</h2></summary>
+<summary><h3>test-suites (169855.5ms)</h3></summary>
 
 | test-suites | hermes (test) |
 |---|---:|
@@ -87,9 +86,8 @@
 | protoCache | 2354ms |
 
 </details>
-
 <details>
-<summary><h2>micros (31667ms)</h2></summary>
+<summary><h3>micros (31667ms)</h3></summary>
 
 | micros | hermes (test) |
 |---|---:|
@@ -99,9 +97,8 @@
 | typed-array-sort.js | 22458ms |
 
 </details>
-
 <details>
-<summary><h2>jit-benches (3940ms)</h2></summary>
+<summary><h3>jit-benches (3940ms)</h3></summary>
 
 | jit-benches | hermes (test) |
 |---|---:|
@@ -109,9 +106,8 @@
 | idispn.js | 2013ms |
 
 </details>
-
 <details>
-<summary><h2>many-subclasses (50392ms)</h2></summary>
+<summary><h3>many-subclasses (50392ms)</h3></summary>
 
 | many-subclasses | hermes (test) |
 |---|---:|
@@ -122,9 +118,8 @@
 | many-sh-4.js | 7978ms |
 
 </details>
-
 <details>
-<summary><h2>map-objects (1924ms)</h2></summary>
+<summary><h3>map-objects (1924ms)</h3></summary>
 
 | map-objects | hermes (test) |
 |---|---:|
@@ -132,9 +127,8 @@
 | map-objects-typed.js | 931ms |
 
 </details>
-
 <details>
-<summary><h2>map-strings (2247.5ms)</h2></summary>
+<summary><h3>map-strings (2247.5ms)</h3></summary>
 
 | map-strings | hermes (test) |
 |---|---:|
@@ -142,9 +136,8 @@
 | map-strings-typed.js | 1084ms |
 
 </details>
-
 <details>
-<summary><h2>nbody (2009.5ms)</h2></summary>
+<summary><h3>nbody (2009.5ms)</h3></summary>
 
 | nbody | hermes (test) |
 |---|---:|
@@ -153,18 +146,16 @@
 | fully-typed/nbody.ts | 690ms |
 
 </details>
-
 <details>
-<summary><h2>string-switch (1321ms)</h2></summary>
+<summary><h3>string-switch (1321ms)</h3></summary>
 
 | string-switch (string-switch/plain) | hermes (test) |
 |---|---:|
 | bench.js | 1321ms |
 
 </details>
-
 <details>
-<summary><h2>raytracer (2964.5ms)</h2></summary>
+<summary><h3>raytracer (2964.5ms)</h3></summary>
 
 | raytracer (raytracer/original) | hermes (test) |
 |---|---:|
@@ -172,9 +163,8 @@
 | raytracer.ts | 1538ms |
 
 </details>
-
 <details>
-<summary><h2>MiniReact (16022.5ms)</h2></summary>
+<summary><h3>MiniReact (16022.5ms)</h3></summary>
 
 | MiniReact | hermes (test) |
 |---|---:|
@@ -188,9 +178,8 @@
 | no-objects/out/music.js | 111ms |
 
 </details>
-
 <details>
-<summary><h2>widgets (6989ms)</h2></summary>
+<summary><h3>widgets (6989ms)</h3></summary>
 
 | widgets | hermes (test) |
 |---|---:|

--- a/benchmarks/hermes-windows/2026-3-24.md
+++ b/benchmarks/hermes-windows/2026-3-24.md
@@ -2,100 +2,200 @@
 
 **Total benchmarks:** 102
 
-## v8
+<details>
+<summary><h2>v8 (3256ms)</h2></summary>
 
-| v8 | hermes (test) |  |  |  |  |
-| --- | ---: | --- | ---: | --- | ---: |
-| v8-crypto | 592.5ms | v8-deltablue | 751.5ms | v8-raytrace | 122ms |
-| v8-regexp | 597ms | v8-richards | 975ms | v8-splay | 218ms |
+| v8 | hermes (test) |
+|---|---:|
+| v8-crypto | 592.5ms |
+| v8-deltablue | 751.5ms |
+| v8-raytrace | 122ms |
+| v8-regexp | 597ms |
+| v8-richards | 975ms |
+| v8-splay | 218ms |
 
-## test-suites
+</details>
 
-| test-suites | hermes (test) |  |  |  |  |
-| --- | ---: | --- | ---: | --- | ---: |
-| box2d | 2555.5ms | earley-boyer | 2377ms | navier-stokes | 4314ms |
-| pdfjs | 936ms | gbemu | 2191.5ms | code-load | 4503.5ms |
-| typescript | 3317.5ms | simpleSum | 5630ms | propAccess | 2188.5ms |
-| allocObj | 191ms | allocObjLit | 6123ms | allocNewObj | 19273ms |
-| allocArray | 191.5ms | allocNewArray | 35283ms | arrayRead | 84.5ms |
-| arrayReadByIndex | 603.5ms | largeArrayRead | 526ms | arrayWrite | 239ms |
-| largeArrayWrite | 2151.5ms | interp-dispatch | 1920ms | wb-perf | 9493ms |
-| arrayReverse | 40.5ms | arrayMap | 1474ms | arrayIndexOf | 145ms |
-| arrayLastIndexOf | 145.5ms | arrayEvery | 2214.5ms | arraySome | 2213ms |
-| arrayFill | 2410ms | arrayFilter | 1838.5ms | arrayFind | 3286ms |
-| arrayFindIndex | 3330.5ms | arrayPop | 1049ms | arrayReduce | 2065.5ms |
-| arrayReduceRight | 2090ms | arrayShift | 2093ms | arrayUnshift | 2102.5ms |
-| arrayIncludes | 1189ms | arrayFrom | 1123.5ms | arrayCopyWithin | 1498ms |
-| stringFromCharCode | 90ms | arraySlice | 787ms | arraySplice | 27ms |
-| arrayOf | 1028ms | stringCharAt | 1255.5ms | stringMatch | 2834ms |
-| stringSearch | 2843.5ms | stringStartsWith | 558ms | stringEndsWith | 529.5ms |
-| stringIncludes | 2041.5ms | stringIndexOf | 1461.5ms | stringLastIndexOf | 1946ms |
-| stringSplit | 790ms | stringSlice | 481ms | stringPadStart | 2898ms |
-| stringPadEnd | 2898.5ms | regExpMatch | 1507ms | regExpSearch | 1210ms |
-| regExpToString | 1045.5ms | stringReplace | 1490ms | regExpReplace | 871ms |
-| regExpFlags | 943ms | regExpSplit | 1240.5ms | numberArrayReadWrite | 2325ms |
-| protoCache | 2354ms |  |  |  |  |
+<details>
+<summary><h2>test-suites (169855.5ms)</h2></summary>
 
-## micros
+| test-suites | hermes (test) |
+|---|---:|
+| box2d | 2555.5ms |
+| earley-boyer | 2377ms |
+| navier-stokes | 4314ms |
+| pdfjs | 936ms |
+| gbemu | 2191.5ms |
+| code-load | 4503.5ms |
+| typescript | 3317.5ms |
+| simpleSum | 5630ms |
+| propAccess | 2188.5ms |
+| allocObj | 191ms |
+| allocObjLit | 6123ms |
+| allocNewObj | 19273ms |
+| allocArray | 191.5ms |
+| allocNewArray | 35283ms |
+| arrayRead | 84.5ms |
+| arrayReadByIndex | 603.5ms |
+| largeArrayRead | 526ms |
+| arrayWrite | 239ms |
+| largeArrayWrite | 2151.5ms |
+| interp-dispatch | 1920ms |
+| wb-perf | 9493ms |
+| arrayReverse | 40.5ms |
+| arrayMap | 1474ms |
+| arrayIndexOf | 145ms |
+| arrayLastIndexOf | 145.5ms |
+| arrayEvery | 2214.5ms |
+| arraySome | 2213ms |
+| arrayFill | 2410ms |
+| arrayFilter | 1838.5ms |
+| arrayFind | 3286ms |
+| arrayFindIndex | 3330.5ms |
+| arrayPop | 1049ms |
+| arrayReduce | 2065.5ms |
+| arrayReduceRight | 2090ms |
+| arrayShift | 2093ms |
+| arrayUnshift | 2102.5ms |
+| arrayIncludes | 1189ms |
+| arrayFrom | 1123.5ms |
+| arrayCopyWithin | 1498ms |
+| stringFromCharCode | 90ms |
+| arraySlice | 787ms |
+| arraySplice | 27ms |
+| arrayOf | 1028ms |
+| stringCharAt | 1255.5ms |
+| stringMatch | 2834ms |
+| stringSearch | 2843.5ms |
+| stringStartsWith | 558ms |
+| stringEndsWith | 529.5ms |
+| stringIncludes | 2041.5ms |
+| stringIndexOf | 1461.5ms |
+| stringLastIndexOf | 1946ms |
+| stringSplit | 790ms |
+| stringSlice | 481ms |
+| stringPadStart | 2898ms |
+| stringPadEnd | 2898.5ms |
+| regExpMatch | 1507ms |
+| regExpSearch | 1210ms |
+| regExpToString | 1045.5ms |
+| stringReplace | 1490ms |
+| regExpReplace | 871ms |
+| regExpFlags | 943ms |
+| regExpSplit | 1240.5ms |
+| numberArrayReadWrite | 2325ms |
+| protoCache | 2354ms |
 
-| micros | hermes (test) |  |  |  |  |
-| --- | ---: | --- | ---: | --- | ---: |
-| getNodeById.js | 4779.5ms | setInsert.js | 2657ms | stringify-number.js | 1772.5ms |
-| typed-array-sort.js | 22458ms |  |  |  |  |
+</details>
 
-## jit-benches
+<details>
+<summary><h2>micros (31667ms)</h2></summary>
 
-| jit-benches | hermes (test) |  |  |
-| --- | ---: | --- | ---: |
-| idisp.js | 1927ms | idispn.js | 2013ms |
+| micros | hermes (test) |
+|---|---:|
+| getNodeById.js | 4779.5ms |
+| setInsert.js | 2657ms |
+| stringify-number.js | 1772.5ms |
+| typed-array-sort.js | 22458ms |
 
-## many-subclasses
+</details>
 
-| many-subclasses | hermes (test) |  |  |  |  |
-| --- | ---: | --- | ---: | --- | ---: |
-| many.js | 18218ms | many-sh-1.js | 8153.5ms | many-sh-2.js | 8067.5ms |
-| many-sh-3.js | 7975ms | many-sh-4.js | 7978ms |  |  |
+<details>
+<summary><h2>jit-benches (3940ms)</h2></summary>
 
-## map-objects
+| jit-benches | hermes (test) |
+|---|---:|
+| idisp.js | 1927ms |
+| idispn.js | 2013ms |
 
-| map-objects | hermes (test) |  |  |
-| --- | ---: | --- | ---: |
-| map-objects-untyped.js | 993ms | map-objects-typed.js | 931ms |
+</details>
 
-## map-strings
+<details>
+<summary><h2>many-subclasses (50392ms)</h2></summary>
 
-| map-strings | hermes (test) |  |  |
-| --- | ---: | --- | ---: |
-| map-strings-untyped.js | 1163.5ms | map-strings-typed.js | 1084ms |
+| many-subclasses | hermes (test) |
+|---|---:|
+| many.js | 18218ms |
+| many-sh-1.js | 8153.5ms |
+| many-sh-2.js | 8067.5ms |
+| many-sh-3.js | 7975ms |
+| many-sh-4.js | 7978ms |
 
-## nbody
+</details>
 
-| nbody | hermes (test) |  |  |  |  |
-| --- | ---: | --- | ---: | --- | ---: |
-| original/nbody.js | 704ms | fully-typed/nbody.js | 615.5ms | fully-typed/nbody.ts | 690ms |
+<details>
+<summary><h2>map-objects (1924ms)</h2></summary>
 
-## string-switch
+| map-objects | hermes (test) |
+|---|---:|
+| map-objects-untyped.js | 993ms |
+| map-objects-typed.js | 931ms |
+
+</details>
+
+<details>
+<summary><h2>map-strings (2247.5ms)</h2></summary>
+
+| map-strings | hermes (test) |
+|---|---:|
+| map-strings-untyped.js | 1163.5ms |
+| map-strings-typed.js | 1084ms |
+
+</details>
+
+<details>
+<summary><h2>nbody (2009.5ms)</h2></summary>
+
+| nbody | hermes (test) |
+|---|---:|
+| original/nbody.js | 704ms |
+| fully-typed/nbody.js | 615.5ms |
+| fully-typed/nbody.ts | 690ms |
+
+</details>
+
+<details>
+<summary><h2>string-switch (1321ms)</h2></summary>
 
 | string-switch (string-switch/plain) | hermes (test) |
-| --- | ---: |
+|---|---:|
 | bench.js | 1321ms |
 
-## raytracer
+</details>
 
-| raytracer (raytracer/original) | hermes (test) |  |  |
-| --- | ---: | --- | ---: |
-| bench-raytracer.js | 1426.5ms | raytracer.ts | 1538ms |
+<details>
+<summary><h2>raytracer (2964.5ms)</h2></summary>
 
-## MiniReact
+| raytracer (raytracer/original) | hermes (test) |
+|---|---:|
+| bench-raytracer.js | 1426.5ms |
+| raytracer.ts | 1538ms |
 
-| MiniReact | hermes (test) |  |  |  |  |
-| --- | ---: | --- | ---: | --- | ---: |
-| no-objects/out/simple-stripped.js | 2118ms | no-objects/out/simple-lowered.js | 2151.5ms | no-objects/out/music-stripped.js | 84.5ms |
-| no-objects/out/music-lowered.js | 90ms | no-deps/stripped/MiniReact.js | 4699ms | no-deps/MiniReact.js | 4651ms |
-| no-objects/out/simple.js | 2117.5ms | no-objects/out/music.js | 111ms |  |  |
+</details>
 
-## widgets
+<details>
+<summary><h2>MiniReact (16022.5ms)</h2></summary>
 
-| widgets | hermes (test) |  |  |  |  |
-| --- | ---: | --- | ---: | --- | ---: |
-| simple-classes/widgets.js | 1570ms | original/es5/widgets.js | 2713.5ms | single-file/es5/widgets.js | 2705.5ms |
+| MiniReact | hermes (test) |
+|---|---:|
+| no-objects/out/simple-stripped.js | 2118ms |
+| no-objects/out/simple-lowered.js | 2151.5ms |
+| no-objects/out/music-stripped.js | 84.5ms |
+| no-objects/out/music-lowered.js | 90ms |
+| no-deps/stripped/MiniReact.js | 4699ms |
+| no-deps/MiniReact.js | 4651ms |
+| no-objects/out/simple.js | 2117.5ms |
+| no-objects/out/music.js | 111ms |
+
+</details>
+
+<details>
+<summary><h2>widgets (6989ms)</h2></summary>
+
+| widgets | hermes (test) |
+|---|---:|
+| simple-classes/widgets.js | 1570ms |
+| original/es5/widgets.js | 2713.5ms |
+| single-file/es5/widgets.js | 2705.5ms |
+
+</details>

--- a/benchmarks/hermes-windows/2026-3-24.md
+++ b/benchmarks/hermes-windows/2026-3-24.md
@@ -3,7 +3,7 @@
 **Total benchmarks:** 102
 
 <details>
-<summary><h3>v8 (3256ms)</h3></summary>
+<summary><strong>v8 (3256ms)</strong></summary>
 
 | v8 | hermes (test) |
 |---|---:|
@@ -16,7 +16,7 @@
 
 </details>
 <details>
-<summary><h3>test-suites (169855.5ms)</h3></summary>
+<summary><strong>test-suites (169855.5ms)</strong></summary>
 
 | test-suites | hermes (test) |
 |---|---:|
@@ -87,7 +87,7 @@
 
 </details>
 <details>
-<summary><h3>micros (31667ms)</h3></summary>
+<summary><strong>micros (31667ms)</strong></summary>
 
 | micros | hermes (test) |
 |---|---:|
@@ -98,7 +98,7 @@
 
 </details>
 <details>
-<summary><h3>jit-benches (3940ms)</h3></summary>
+<summary><strong>jit-benches (3940ms)</strong></summary>
 
 | jit-benches | hermes (test) |
 |---|---:|
@@ -107,7 +107,7 @@
 
 </details>
 <details>
-<summary><h3>many-subclasses (50392ms)</h3></summary>
+<summary><strong>many-subclasses (50392ms)</strong></summary>
 
 | many-subclasses | hermes (test) |
 |---|---:|
@@ -119,7 +119,7 @@
 
 </details>
 <details>
-<summary><h3>map-objects (1924ms)</h3></summary>
+<summary><strong>map-objects (1924ms)</strong></summary>
 
 | map-objects | hermes (test) |
 |---|---:|
@@ -128,7 +128,7 @@
 
 </details>
 <details>
-<summary><h3>map-strings (2247.5ms)</h3></summary>
+<summary><strong>map-strings (2247.5ms)</strong></summary>
 
 | map-strings | hermes (test) |
 |---|---:|
@@ -137,7 +137,7 @@
 
 </details>
 <details>
-<summary><h3>nbody (2009.5ms)</h3></summary>
+<summary><strong>nbody (2009.5ms)</strong></summary>
 
 | nbody | hermes (test) |
 |---|---:|
@@ -147,7 +147,7 @@
 
 </details>
 <details>
-<summary><h3>string-switch (1321ms)</h3></summary>
+<summary><strong>string-switch (1321ms)</strong></summary>
 
 | string-switch (string-switch/plain) | hermes (test) |
 |---|---:|
@@ -155,7 +155,7 @@
 
 </details>
 <details>
-<summary><h3>raytracer (2964.5ms)</h3></summary>
+<summary><strong>raytracer (2964.5ms)</strong></summary>
 
 | raytracer (raytracer/original) | hermes (test) |
 |---|---:|
@@ -164,7 +164,7 @@
 
 </details>
 <details>
-<summary><h3>MiniReact (16022.5ms)</h3></summary>
+<summary><strong>MiniReact (16022.5ms)</strong></summary>
 
 | MiniReact | hermes (test) |
 |---|---:|
@@ -179,7 +179,7 @@
 
 </details>
 <details>
-<summary><h3>widgets (6989ms)</h3></summary>
+<summary><strong>widgets (6989ms)</strong></summary>
 
 | widgets | hermes (test) |
 |---|---:|

--- a/benchmarks/hermes-windows/report.ts
+++ b/benchmarks/hermes-windows/report.ts
@@ -199,6 +199,11 @@ const totalCount = new Set(datasets.flatMap((d) => Object.keys(d.results))).size
 lines.push(`**Total benchmarks:** ${totalCount}`);
 lines.push('');
 
+if (datasets.length > 1) {
+  lines.push(`**Runtimes:** ${runtimeNames.join(', ')}`);
+  lines.push('');
+}
+
 for (const group of groupOrder) {
   const benchNames = groupBenchmarks.get(group)!;
   lines.push(...renderSection(group, benchNames));

--- a/benchmarks/hermes-windows/report.ts
+++ b/benchmarks/hermes-windows/report.ts
@@ -155,7 +155,7 @@ function renderSection(group: string, benchNames: string[]): string[] {
   // Foldable section with a heading-styled summary, e.g.
   //   <details><summary><h2>v8 (3256ms)</h2></summary>
   out.push(`<details>`);
-  out.push(`<summary><h3>${group} (${sumStr})</h3></summary>`);
+  out.push(`<summary><strong>${group} (${sumStr})</strong></summary>`);
   out.push('');
 
   // Table header: column 1 = group title (with optional path annotation),

--- a/benchmarks/hermes-windows/report.ts
+++ b/benchmarks/hermes-windows/report.ts
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 
 // ---------------------------------------------------------------------------
@@ -200,7 +201,14 @@ lines.push(`**Total benchmarks:** ${totalCount}`);
 lines.push('');
 
 if (datasets.length > 1) {
-  lines.push(`**Runtimes:** ${runtimeNames.join(', ')}`);
+  // Show input paths relative to this script's folder
+  // (benchmarks/hermes-windows). Runtime labels are often identical
+  // across inputs in real runs, so they don't help disambiguate.
+  const reportDir = import.meta.dirname;
+  const inputPaths = inputs.map((p) =>
+    relative(reportDir, resolve(p)).replaceAll('\\', '/'),
+  );
+  lines.push(`**Inputs:** ${inputPaths.join(', ')}`);
   lines.push('');
 }
 

--- a/benchmarks/hermes-windows/report.ts
+++ b/benchmarks/hermes-windows/report.ts
@@ -155,7 +155,7 @@ function renderSection(group: string, benchNames: string[]): string[] {
   // Foldable section with a heading-styled summary, e.g.
   //   <details><summary><h2>v8 (3256ms)</h2></summary>
   out.push(`<details>`);
-  out.push(`<summary><h2>${group} (${sumStr})</h2></summary>`);
+  out.push(`<summary><h3>${group} (${sumStr})</h3></summary>`);
   out.push('');
 
   // Table header: column 1 = group title (with optional path annotation),
@@ -187,7 +187,6 @@ function renderSection(group: string, benchNames: string[]): string[] {
 
   out.push('');
   out.push(`</details>`);
-  out.push('');
   return out;
 }
 

--- a/benchmarks/hermes-windows/report.ts
+++ b/benchmarks/hermes-windows/report.ts
@@ -53,7 +53,6 @@ const datasets: BenchData[] = inputs.map(
 );
 
 const runtimeNames = datasets.map((d, i) => d.runtime || `input-${i + 1}`);
-const multiInput = datasets.length > 1;
 
 // ---------------------------------------------------------------------------
 // Collect all benchmark names and group them
@@ -124,6 +123,74 @@ function stripPathPrefix(name: string, prefixLen: number): string {
 // Generate markdown
 // ---------------------------------------------------------------------------
 
+// Render a single group section. Used for both single-input (one runtime
+// column) and comparison (multiple runtime columns) modes — the only
+// difference is how many value columns there are and whether the row
+// minimum is bolded.
+function renderSection(group: string, benchNames: string[]): string[] {
+  const out: string[] = [];
+
+  // Per-dataset sums of all benchmark means in this group, used in the
+  // foldable title.
+  const sums: number[] = meanLookup.map((lookup) => {
+    let s = 0;
+    for (const name of benchNames) {
+      const v = lookup.get(name);
+      if (v !== undefined) s += v;
+    }
+    return s;
+  });
+  const sumStr = sums.map((s) => `${s}ms`).join(', ');
+
+  // Factor out the longest path prefix shared by every name in this group.
+  // When present, the prefix is stripped from each row cell. The header
+  // cell shows `(<prefix>)` only when it carries new info beyond the
+  // group name — if prefix == group the annotation is redundant.
+  const prefix = commonPathPrefix(benchNames);
+  const prefixStr = prefix.join('/');
+  const titleCell = prefix.length > 0 && prefixStr !== group
+    ? `${group} (${prefixStr})`
+    : group;
+
+  // Foldable section with a heading-styled summary, e.g.
+  //   <details><summary><h2>v8 (3256ms)</h2></summary>
+  out.push(`<details>`);
+  out.push(`<summary><h2>${group} (${sumStr})</h2></summary>`);
+  out.push('');
+
+  // Table header: column 1 = group title (with optional path annotation),
+  // remaining columns = one per dataset/runtime.
+  const header = [titleCell, ...runtimeNames];
+  out.push('| ' + header.join(' | ') + ' |');
+  out.push('|---|' + runtimeNames.map(() => '---:|').join(''));
+
+  // One benchmark per row.
+  const compare = datasets.length > 1;
+  for (const name of benchNames) {
+    const vals = meanLookup.map((lookup) => lookup.get(name));
+    const cells: string[] = [stripPathPrefix(name, prefix.length)];
+    if (compare) {
+      const defined = vals.filter((v): v is number => v !== undefined);
+      const min = defined.length > 0 ? Math.min(...defined) : undefined;
+      for (const v of vals) {
+        if (v === undefined) cells.push('-');
+        else if (v === min) cells.push(`**${v}ms**`);
+        else cells.push(`${v}ms`);
+      }
+    } else {
+      for (const v of vals) {
+        cells.push(v === undefined ? '-' : `${v}ms`);
+      }
+    }
+    out.push('| ' + cells.join(' | ') + ' |');
+  }
+
+  out.push('');
+  out.push(`</details>`);
+  out.push('');
+  return out;
+}
+
 const lines: string[] = [];
 
 lines.push(`# Benchmark Results`);
@@ -135,86 +202,7 @@ lines.push('');
 
 for (const group of groupOrder) {
   const benchNames = groupBenchmarks.get(group)!;
-
-  // Factor out the longest path prefix shared by every name in this group.
-  // When present, the prefix is stripped from each row cell. The parenthetical
-  // `(<prefix>)` is appended to the header only when it carries new info
-  // beyond the group name — if prefix == group the annotation would be
-  // redundant (`micros (micros)`), so omit it.
-  const prefix = commonPathPrefix(benchNames);
-  const prefixStr = prefix.join('/');
-  const titleCell = prefix.length > 0 && prefixStr !== group
-    ? `${group} (${prefixStr})`
-    : group;
-
-  lines.push(`## ${group}`);
-  lines.push('');
-
-  if (multiInput) {
-    // Compare mode: one column per runtime. Group+prefix goes in column 1
-    // header (replacing the old `## <group>` heading + "Benchmark (ms)" label).
-    const header = [titleCell, ...runtimeNames];
-    lines.push('| ' + header.join(' | ') + ' |');
-    lines.push(
-      '|' +
-        header.map((_, i) => (i === 0 ? '---|' : '---:|')).join(''),
-    );
-
-    for (const name of benchNames) {
-      const vals = meanLookup.map((lookup) => lookup.get(name));
-      const defined = vals.filter((v): v is number => v !== undefined);
-      const min = defined.length > 0 ? Math.min(...defined) : undefined;
-      const cells: string[] = [stripPathPrefix(name, prefix.length)];
-      for (const v of vals) {
-        if (v === undefined) cells.push('-');
-        else if (v === min) cells.push(`**${v}ms**`);
-        else cells.push(`${v}ms`);
-      }
-      lines.push('| ' + cells.join(' | ') + ' |');
-    }
-    lines.push('');
-    continue;
-  }
-
-  // Single-input: pack up to 3 benchmarks per row (N1 T1 N2 T2 N3 T3).
-  // If the group has fewer than 3 benchmarks total, shrink the column count
-  // so no entire column is left empty.
-  const lookup = meanLookup[0];
-  const packWidth = Math.min(3, benchNames.length);
-  const totalCols = packWidth * 2;
-
-  // Header row: col 1 = group title (with common path), col 2 = runtime
-  // label, rest empty.
-  const headerCells: string[] = new Array(totalCols).fill('');
-  headerCells[0] = titleCell;
-  headerCells[1] = runtimeNames[0];
-  lines.push('| ' + headerCells.join(' | ') + ' |');
-
-  // Separator: name cols left-aligned, time cols right-aligned.
-  const sep: string[] = [];
-  for (let c = 0; c < totalCols; c++) {
-    sep.push(c % 2 === 0 ? '---' : '---:');
-  }
-  lines.push('| ' + sep.join(' | ') + ' |');
-
-  // Body rows, packed.
-  for (let i = 0; i < benchNames.length; i += packWidth) {
-    const row: string[] = [];
-    for (let j = 0; j < packWidth; j++) {
-      const idx = i + j;
-      if (idx < benchNames.length) {
-        const name = benchNames[idx];
-        const v = lookup.get(name);
-        row.push(stripPathPrefix(name, prefix.length));
-        row.push(v === undefined ? '-' : `${v}ms`);
-      } else {
-        row.push('');
-        row.push('');
-      }
-    }
-    lines.push('| ' + row.join(' | ') + ' |');
-  }
-  lines.push('');
+  lines.push(...renderSection(group, benchNames));
 }
 
 const md = lines.join('\n');


### PR DESCRIPTION
## Summary

Rework the benchmark report to be foldable, each benchmark category is collapsed by default, and in the title there are also sum of times, therefore without expanding to read the details we can still get a overall sense of performance changing.

A comparison report is also prepared, but it has not been integrated into CI yet. This will be handled in the next CI PR, therefore when baseline exists a comparison report will be generated, instead of just the data of the current PR.

## Test Plan

Manual tested

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/319)