### PR TITLE
Fix GC unsafe code in Node-API

### DIFF
--- a/.ado/build-template.yml
+++ b/.ado/build-template.yml
@@ -13,6 +13,13 @@ parameters:
   type: boolean
   default: false
 
+  # Build with HERMESVM_SANITIZE_HANDLES=ON to deterministically surface GC-safety
+  # bugs (the GC moves the heap after every allocation). Off by default; enable it
+  # for diagnostic / red-green test runs.
+- name: SanitizeHandles
+  type: boolean
+  default: false
+
   # Matrix with target platforms for Hermes binaries.
 - name: BuildMatrix
   type: object
@@ -141,6 +148,11 @@ extends:
               value: --fake-build
             ${{ else }}:
               value: --no-fake-build
+          - name: sanitizeHandlesArg
+            ${{ if eq(parameters.SanitizeHandles, true) }}:
+              value: --sanitize-handles
+            ${{ else }}:
+              value: --no-sanitize-handles
 
           templateContext:
             outputs:
@@ -166,6 +178,7 @@ extends:
               --semantic-version "$(semanticVersion)"
               --file-version "$(fileVersion)"
               $(fakeBuildArg)
+              $(sanitizeHandlesArg)
             displayName: Build binaries
 
             # Show all built files to help debug issues.
@@ -186,6 +199,7 @@ extends:
                 --semantic-version "$(semanticVersion)"
                 --file-version "$(fileVersion)"
                 $(fakeBuildArg)
+                $(sanitizeHandlesArg)
               displayName: Run unit tests
 
             # Run Lit tests which are mostly JS tests.
@@ -200,6 +214,7 @@ extends:
                 --semantic-version "$(semanticVersion)"
                 --file-version "$(fileVersion)"
                 $(fakeBuildArg)
+                $(sanitizeHandlesArg)
               displayName: Run JS regression tests
 
             # Run Test262 Intl tests.
@@ -214,6 +229,7 @@ extends:
                 --semantic-version "$(semanticVersion)"
                 --file-version "$(fileVersion)"
                 $(fakeBuildArg)
+                $(sanitizeHandlesArg)
               displayName: Run Test262 Intl tests
 
             # Sign and publish symbols only for the CI builds and real builds.

--- a/.ado/scripts/build.js
+++ b/.ado/scripts/build.js
@@ -67,6 +67,12 @@ const options = {
   "test262-intl": { type: "boolean", default: false },
   "intl-provider": { type: "string", default: "" },
   binskim: { type: "boolean", default: false },
+  "sanitize-handles": { type: "boolean", default: false },
+  "gc-kind": {
+    type: "string",
+    default: "hades",
+    validSet: ["hades", "malloc"],
+  },
 };
 
 // To access parsed args values, use args.<option-name>.
@@ -151,6 +157,23 @@ Options:
   --binskim               Run BinSkim security validation on shipped binaries (default: ${
     options.binskim.default
   })
+  --sanitize-handles      Build with HERMESVM_SANITIZE_HANDLES=ON to deterministically
+                          surface GC-safety bugs (the GC moves the heap after every
+                          allocation). Slower; use for diagnostic / red-green test runs
+                          and pair with --configure (or --clean-build) so the CMake
+                          cache picks up the change. (default: ${
+                            options["sanitize-handles"].default
+                          })
+                          Note: under HadesGC this only forces OG compaction during
+                          OG collections, so subtle GC bugs may stay hidden. Pair
+                          with --gc-kind malloc for true per-allocation movement.
+  --gc-kind               GC implementation to compile in (default: ${
+                            options["gc-kind"].default
+                          }) [valid values: ${options["gc-kind"].validSet.join(", ")}]
+                          Sets HERMESVM_GCKIND. Use "malloc" together with
+                          --sanitize-handles for deterministic GC-safety tests
+                          (every alloc moves the heap). Requires --configure or
+                          --clean-build to take effect on existing builds.
 
 Examples:
   node ${scriptRelativePath} --configure --no-build        # Configure only, don't build
@@ -242,6 +265,8 @@ function main() {
   console.log(`         test262-intl: ${args["test262-intl"]}`);
   console.log(`        intl-provider: ${args["intl-provider"]}`);
   console.log(`              binskim: ${args.binskim}`);
+  console.log(`     sanitize-handles: ${args["sanitize-handles"]}`);
+  console.log(`              gc-kind: ${args["gc-kind"]}`);
   console.log();
 
   removeUnusedFilesForComponentGovernance();
@@ -538,6 +563,17 @@ function cmakeConfigure(buildParams) {
       genArgs.push(`-DSHERMES_CC_SYSCFLAGS="-target ${shermesTarget}"`);
     }
   }
+
+  // Toggle HERMESVM_SANITIZE_HANDLES. Set explicitly in both directions so a
+  // prior cached value does not stick across builds.
+  genArgs.push(
+    `-DHERMESVM_SANITIZE_HANDLES=${args["sanitize-handles"] ? "ON" : "OFF"}`,
+  );
+
+  // Select the GC implementation. CMake expects HADES or MALLOC (uppercase).
+  genArgs.push(
+    `-DHERMESVM_GCKIND=${args["gc-kind"] === "malloc" ? "MALLOC" : "HADES"}`,
+  );
 
   // Pass external ICU path for testing if available, or clear cache value.
   if (buildParams.externalIcuDir) {

--- a/API/hermes_node_api/hermes_node_api.cpp
+++ b/API/hermes_node_api/hermes_node_api.cpp
@@ -1770,14 +1770,20 @@ class NodeApiReference : public NodeApiRefTracker {
       const vm::PinnedHermesValue *value,
       uint32_t initialRefCount,
       NodeApiReferenceOwnership ownership) noexcept {
-    // Make sure GC does not collect the value while we create the reference.
     vm::GCScope scope{env.runtime()};
-    // vm::Handle<vm::HermesValue> handleValue =
-    // env.runtime().makeHandle(*value);
 
     NodeApiReference *reference = new (std::nothrow)
         NodeApiReference(env, value, initialRefCount, ownership);
     env.addReference(reference);
+    // Register the reference as a GC root *before* running
+    // convertToWeakRootStorage, since that path triggers JS allocations
+    // (createExternalObject + defineOwnProperty on the underlying object,
+    // which may be a JSProxy). Without this ordering, value_ is not yet
+    // visible to NodeApiReference::getGCRoots and a moving GC inside
+    // addObjectFinalizer would leave it pointing at a freed cell.
+    if (initialRefCount == 0) {
+      reference->convertToWeakRootStorage(env);
+    }
     return reference;
   }
 
@@ -1870,9 +1876,13 @@ class NodeApiReference : public NodeApiRefTracker {
         refCount_(initialRefCount),
         ownership_(ownership),
         canBeWeak_(сanBeHeldWeakly(value)) {
-    if (refCount_ == 0) {
-      convertToWeakRootStorage(env);
-    }
+    // Note: convertToWeakRootStorage() must NOT be called from the
+    // constructor when initialRefCount == 0 — at that point `this` has
+    // not yet been added to env.references_ via addReference(), so
+    // value_ is not a registered GC root and an allocation inside
+    // addObjectFinalizer would corrupt it. The owning create() function
+    // is responsible for invoking convertToWeakRootStorage() *after*
+    // registering the reference.
   }
 
   virtual void callUserFinalizer() noexcept {
@@ -1978,6 +1988,10 @@ class NodeApiReference : public NodeApiRefTracker {
     isUsingWeakStorage_ = false;
   }
 
+  // Accessible to the derived classes' static create() functions, which
+  // must invoke this *after* registering the new reference in env's
+  // tracking list (see NodeApiReference::create comment).
+ protected:
   void convertToWeakRootStorage(NodeApiEnvironment &env) noexcept {
     if (isUsingWeakStorage_) {
       return; // It is already a weak storage.
@@ -2017,6 +2031,7 @@ class NodeApiReference : public NodeApiRefTracker {
     isUsingWeakStorage_ = true;
   }
 
+ private:
   napi_value getStorageValue(NodeApiEnvironment &env) const noexcept {
     vm::PinnedHermesValue rawValue;
 
@@ -2072,6 +2087,9 @@ class NodeApiReferenceWithData final : public NodeApiReference {
         new (std::nothrow) NodeApiReferenceWithData(
             env, value, initialRefCount, ownership, nativeData);
     env.addReference(reference);
+    if (initialRefCount == 0) {
+      reference->convertToWeakRootStorage(env);
+    }
     return reference;
   }
 
@@ -2120,6 +2138,9 @@ class NodeApiReferenceWithFinalizer final : public NodeApiReference {
             finalizeCallback,
             finalizeHint);
     env.addFinalizingReference(reference);
+    if (initialRefCount == 0) {
+      reference->convertToWeakRootStorage(env);
+    }
     return reference;
   }
 

--- a/API/jsi/jsi/test/testlib_ext.cpp
+++ b/API/jsi/jsi/test/testlib_ext.cpp
@@ -281,6 +281,74 @@ TEST_P(JSITestExt, WeakReferences) {
   EXPECT_TRUE(wo.lock(rt).isUndefined());
 }
 
+// Regression test for a GC-safety bug in the Hermes Node-API
+// implementation: NodeApiReference::create() called
+// convertToWeakRootStorage() from the constructor *before* registering the
+// reference as a GC root via env.addReference(). When the underlying
+// JSObject was a JS Proxy (as is the case for Fabric instance handles in
+// React Native Windows), the call into addObjectFinalizer() ->
+// JSObject::defineOwnProperty() -> JSProxy::defineOwnProperty() allocated
+// inside that unrooted window. A collection triggered there would move
+// the JSObject; the still-unrooted value_ member retained a stale
+// pointer, and the subsequent dispatch into detail::slots() crashed
+// reading proxy->slots_, and the sibling weakRoot_ encoded a stale
+// target.
+//
+// Reproduction strategy: between every WeakObject creation we keep the
+// proxy strongly reachable (in the previous iteration's `prev` slot) and
+// drop the local. Then we call gc() once per iteration. With
+// HERMESVM_SANITIZE_HANDLES=ON the GC compacts the OG, so the proxy gets
+// relocated. If value_ was unrooted at any point during convertToWeakRoot
+// Storage, lock() in the second pass returns a stale pointer that either
+// crashes or fails the property check.
+//
+// Note that with HadesGC the per-allocation movement promised by
+// HERMESVM_SANITIZE_HANDLES is approximated by forcing OG compaction
+// (lib/VM/gcs/HadesGC.cpp prepareCompactee). True per-alloc movement is
+// only available with MallocGC (HERMESVM_GCKIND=MALLOC). For the most
+// reliable repro, build with the MallocGC variant.
+//
+//   .\dev build --clean-build --configure --configuration debug \
+//       --sanitize-handles --test
+TEST_P(JSITestExt, WeakObjectOverProxyRegressionTest) {
+  constexpr int kIterations = 256;
+
+  std::vector<WeakObject> weakRefs;
+  weakRefs.reserve(kIterations);
+
+  // Keep one strong root in JS for each iteration so the GC does not just
+  // collect the proxy outright — we want it relocated, not freed.
+  rt.global().setProperty(rt, "__rnw_proxy_keepalive", Array(rt, kIterations));
+
+  for (int i = 0; i < kIterations; ++i) {
+    Object proxy = eval("new Proxy({tag: 'rnw-proxy'}, {})").getObject(rt);
+    rt.global()
+        .getPropertyAsObject(rt, "__rnw_proxy_keepalive")
+        .asArray(rt)
+        .setValueAtIndex(rt, i, proxy);
+
+    // The actual repro target: createWeakObject() over a Proxy. The
+    // implementation calls napi_create_reference(... initialRefCount=0 ...)
+    // inside its NodeApiScope destructor, which is the unsafe window.
+    weakRefs.emplace_back(rt, proxy);
+
+    // Force a collection. With sanitize-handles + HadesGC this forces an
+    // OG compaction on every gc() call, relocating the proxy.
+    eval("gc()");
+  }
+
+  // Lock every weak ref. If value_ / weakRoot_ ever pointed at a stale
+  // location, this loop will either crash inside JSProxy::defineOwnProperty
+  // or return a target whose property reads come back wrong/undefined.
+  for (size_t i = 0; i < weakRefs.size(); ++i) {
+    Value locked = weakRefs[i].lock(rt);
+    ASSERT_TRUE(locked.isObject()) << "weakRefs[" << i << "] locked to non-object";
+    Value tag = locked.getObject(rt).getProperty(rt, "tag");
+    ASSERT_TRUE(tag.isString()) << "weakRefs[" << i << "].tag is not a string";
+    EXPECT_EQ(tag.getString(rt).utf8(rt), "rnw-proxy");
+  }
+}
+
 TEST_P(JSITestExt, HostObjectAsParentTest) {
   class HostObjectWithProp : public HostObject {
     Value get(Runtime& runtime, const PropNameID& name) override {
@@ -560,7 +628,7 @@ TEST_P(JSITestExt, NativeExceptionDoesNotUseGlobalError) {
       test.call(rt).getString(rt).utf8(rt));
 }
 
-INSTANTIATE_TEST_SUITE_P(
+INSTANTIATE_TEST_CASE_P(
     Runtimes,
     JSITestExt,
     ::testing::ValuesIn(runtimeGenerators()));

--- a/lib/VM/GCBase.cpp
+++ b/lib/VM/GCBase.cpp
@@ -59,7 +59,15 @@ GCBase::GCBase(
       samplingAllocationTracker_(this),
 #endif
 #if HERMESVM_SANITIZE_HANDLES != 0
-      sanitizeRate_(gcConfig.getSanitizeConfig().getSanitizeRate()),
+      // When the build is compiled with HERMESVM_SANITIZE_HANDLES, default the
+      // runtime rate to 1.0 (move the heap on every alloc) unless an explicit
+      // positive rate was supplied via GCConfig. The public default in
+      // GCSanitizeConfig is 0.0 so without this override the build-time flag
+      // would be a no-op at runtime.
+      sanitizeRate_(
+          gcConfig.getSanitizeConfig().getSanitizeRate() > 0.0
+              ? gcConfig.getSanitizeConfig().getSanitizeRate()
+              : 1.0),
 #endif
       tripwireCallback_(gcConfig.getTripwireConfig().getCallback()),
       tripwireLimit_(gcConfig.getTripwireConfig().getLimit()) {

--- a/unittests/NodeApiJsi/CMakeLists.txt
+++ b/unittests/NodeApiJsi/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LLVM_ENABLE_RTTI ON)
 add_hermes_unittest(NodeApiJsiTest
   NodeApiJsiTestFactory.cpp
   ${HERMES_JSI_DIR}/jsi/test/testlib.cpp
+  ${HERMES_JSI_DIR}/jsi/test/testlib_ext.cpp
 )
 
 target_link_libraries(NodeApiJsiTest


### PR DESCRIPTION
## Summary

Fixes a GC-safety bug in the Node-API implementation that could crash
the runtime when creating a weak `napi_ref` over a JS Proxy.

`NodeApiReference::create` invoked `convertToWeakRootStorage` from the
constructor *before* the new reference was registered as a GC root via
`env.addReference()`. `convertToWeakRootStorage` calls
`addObjectFinalizer` → `defineOwnProperty`, which can allocate. If a
moving collection ran during that window the reference's `value_`
member was left pointing at the cell's old location, and the next
dispatch into `JSProxy::defineOwnProperty` faulted reading `slots_`
through a stale pointer.

Fix: register the reference (or finalizing reference) first, then call
`convertToWeakRootStorage` from the static `create(...)` function only
when `initialRefCount == 0`. The same shape is applied to all three
`create` paths (base, `WithData`, `WithFinalizer`). With the reference
on the tracked list, `NodeApiReference::getGCRoots` keeps `value_`
visited across any GC inside `addObjectFinalizer`.

## Supporting changes

- **`GCBase.cpp`**: when the build defines `HERMESVM_SANITIZE_HANDLES`,
  default the runtime `sanitizeRate_` to `1.0` if the `GCConfig`
  rate is `0.0`. Previously the build-time flag was a no-op at runtime
  unless the embedder explicitly called
  `GCSanitizeConfig::Builder().withSanitizeRate(...)`. This change is
  what made it possible to reproduce the crash in a unit test.
- **`build.js` / `build-template.yml`**: new `--sanitize-handles` and
  `--gc-kind hades|malloc` flags (and the matching `SanitizeHandles`
  pipeline parameter) so a diagnostic build is a one-line invocation.
- **`testlib_ext.cpp`** (wired into `NodeApiJsiTest` via
  `unittests/NodeApiJsi/CMakeLists.txt`): new
  `WeakObjectOverProxyRegressionTest` exercises the previously buggy
  path. Without the fix, the test asserts in `JSObject::findProperty`
  reading `0xCC`-poisoned bytes from a freed cell. With the fix, the
  test passes.

## Test Plan

Diagnostic build:

```
.\dev build --configure --configuration debug --sanitize-handles \
            --gc-kind malloc --targets NodeApiJsiTest
```

Then run the test binary:

```
out\build\win32-x64-debug\unittests\NodeApiJsi\NodeApiJsiTest.exe
```

- Reverting just `API/hermes_node_api/hermes_node_api.cpp` from this
  commit to its pre-fix version reproduces the crash deterministically
  in `WeakObjectOverProxyRegressionTest` (assertion failure in
  `JSObject::findProperty` after ~18 s).
- With the fix in place, the targeted regression test passes in ~2 min
  with ~24 000 sanitize-handles collections.
- Full `NodeApiJsiTest` (57 tests, including the new regression test
  and the existing `WeakReferences`) passes under sanitize-handles +
  MallocGC.
- Default release/debug builds (no sanitizer, HadesGC) are unchanged.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/321)