### PR TITLE
Fix using Cyrillic "c"

### DIFF
--- a/API/hermes_node_api/hermes_node_api.cpp
+++ b/API/hermes_node_api/hermes_node_api.cpp
@@ -1875,7 +1875,7 @@ class NodeApiReference : public NodeApiRefTracker {
         value_(*value),
         refCount_(initialRefCount),
         ownership_(ownership),
-        canBeWeak_(сanBeHeldWeakly(value)) {
+        canBeWeak_(canBeHeldWeakly(value)) {
     // Note: convertToWeakRootStorage() must NOT be called from the
     // constructor when initialRefCount == 0 — at that point `this` has
     // not yet been added to env.references_ via addReference(), so
@@ -1941,7 +1941,7 @@ class NodeApiReference : public NodeApiRefTracker {
     }
   }
 
-  static bool сanBeHeldWeakly(const vm::PinnedHermesValue *value) {
+  static bool canBeHeldWeakly(const vm::PinnedHermesValue *value) {
     // Note that Hermes does not support weak symbols yet.
     return value != nullptr && value->isObject();
   }


### PR DESCRIPTION
## Summary

Rename `сanBeHeldWeakly` → `canBeHeldWeakly` in
`API/hermes_node_api/hermes_node_api.cpp`. The leading character was
U+0441 `CYRILLIC SMALL LETTER ES`, not U+0063 `LATIN SMALL LETTER C`.
The code compiled because the declaration and the single caller used
the same Cyrillic glyph, but homoglyphs in identifiers break code
search, IDE navigation, and external tooling, and they're a known
attack surface for malicious obfuscation.

Two occurrences renamed:

- The declaration of the static helper.
- The one caller in the `NodeApiReference` constructor's member
  initializer list.

Verified that this Cyrillic letter did not come from upstream
Node.js: a homoglyph scan of `node/src` (445 files) and `node/test`
returned zero Cyrillic findings. After the rename, a scan of the
hermes-windows tree shows no Cyrillic letters anywhere in
production code; the remaining Cyrillic findings are intentional
test fixtures (Test262 collator inputs, Hermes string-handling
tests).

## Test Plan

- Built `hermes.dll` and `NodeApiJsiTest` clean — both call sites
  now resolve against the same Latin identifier.
- No behavior change: the function body is unchanged and the
  rename is purely cosmetic at the source level.
- Re-ran a homoglyph scan over the whole repo to confirm no other
  mixed-script identifiers exist in code.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/322)