### PR TITLE
Render comparison report in CI when baseline.json exists

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,9 +30,18 @@ jobs:
       - name: Run benchmarks
         shell: bash
         run: |
+          BASELINE="benchmarks/hermes-windows/baseline/baseline.json"
+          EXTRA_ARGS=()
+          if [ -f "$BASELINE" ]; then
+            echo "Baseline found at $BASELINE — generating comparison report."
+            EXTRA_ARGS+=(--baseline "$BASELINE")
+          else
+            echo "No baseline at $BASELINE — generating single-input report."
+          fi
           node --experimental-strip-types \
             benchmarks/hermes-windows/bench_and_report.ts \
-            --binary out/build/win32-x64-release/bin/hermes.exe
+            --binary out/build/win32-x64-release/bin/hermes.exe \
+            "${EXTRA_ARGS[@]}"
 
       - name: Commit baseline if missing
         if: success() && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)

--- a/benchmarks/hermes-windows/bench_and_report.ts
+++ b/benchmarks/hermes-windows/bench_and_report.ts
@@ -10,6 +10,7 @@ const __dirname = dirname(__filename);
 const { values } = parseArgs({
   options: {
     binary: { type: 'string', short: 'b' },
+    baseline: { type: 'string' },
   },
   strict: false,
 });
@@ -42,12 +43,20 @@ const resultObj = JSON.parse(readFileSync(resultJson, 'utf8'));
 resultObj.timestamp = new Date().toISOString();
 writeFileSync(resultJson, JSON.stringify(resultObj, undefined, 4) + '\n');
 
-// Step 2: Generate report
+// Step 2: Generate report. If --baseline <path> is given, render
+// comparison mode with baseline first and the new result second.
 console.log('');
 console.log('=== Generating report ===');
+const reportArgs = ['--experimental-strip-types', reportScript];
+if (values.baseline) {
+  reportArgs.push('-i', values.baseline, '-i', resultJson);
+} else {
+  reportArgs.push('-i', resultJson);
+}
+reportArgs.push('-o', reportMd);
 const reportResult = spawnSync(
   process.execPath,
-  ['--experimental-strip-types', reportScript, '-i', resultJson, '-o', reportMd],
+  reportArgs,
   { stdio: 'inherit' },
 );
 


### PR DESCRIPTION
## Summary

`benchmark/hermes-windows/baseline/baseline.json` is the **latest** created baseline. If this file exist, CI should post a comment comparing the benchmark of the current pull request against that file.

No protocol about how to store history baseline files, but they are just files anyway.

## Test Plan


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/323)