### PR TITLE
Use ARM64 VM image in PR/CI

### DIFF
--- a/.ado/build-template.yml
+++ b/.ado/build-template.yml
@@ -125,12 +125,6 @@ extends:
           value: ${{ parameters.MustPublish }}
 
         steps:
-          # 24.x is the version installed on the build images.
-        - task: UseNode@1
-          displayName: Use Node.js 24.x
-          inputs:
-            version: 24.x
-
           # Compute the semanticVersion and fileVersion, and then update the build title.
         - script: node .ado\scripts\setVersionNumber.js
           name: setVersions # For output variable prefix
@@ -181,12 +175,6 @@ extends:
             # Must run before anything else on the agent - see the template.
           - ${{ if eq(MatrixEntry.UseArm64Pool, true) }}:
             - template: /.ado/ensure-node10-shim.yml@self
-
-            # 24.x is the version installed on the build images.
-          - task: UseNode@1
-            displayName: Use Node.js 24.x
-            inputs:
-              version: 24.x
 
             # Invoke the build specific for the target platform.
           - script: >
@@ -329,12 +317,6 @@ extends:
             artifactName: published-packages
 
         steps:
-          # 24.x is the version installed on the build images.
-        - task: UseNode@1
-          displayName: Use Node.js 24.x
-          inputs:
-            version: 24.x
-
           # The substitution tags in the nuspec require that we use at least NuGet 4.6.
         - task: NuGetToolInstaller@0
           displayName: Install NuGet tools

--- a/.ado/build-template.yml
+++ b/.ado/build-template.yml
@@ -44,12 +44,23 @@ parameters:
   - Name: win32_arm64
     TargetCPU: arm64
     BuildUWP: --no-uwp
+    CanRunTest: true
+    # ARM64 binaries cannot execute on an x64 agent: build.js would only
+    # cross-compile the shared libraries and skip every test. Run this cell on
+    # the native ARM64 pool instead. The UWP ARM64 cell stays on x64 - UWP
+    # binaries are not executed by the pipeline on any architecture.
+    UseArm64Pool: true
     # ARM64 "Emulation Compatible" is to run ARM64 Hermes DLL in a x64 app
     # on Windows ARM64 in emulation mode.
     # See: https://learn.microsoft.com/en-us/windows/arm/arm64ec
   - Name: win32_arm64ec
     TargetCPU: arm64ec
     BuildUWP: --no-uwp
+    # ARM64EC code executes natively on Windows on ARM, so the ARM64 pool builds
+    # this cell as a native build: the test binaries are themselves ARM64EC and
+    # load the ARM64EC hermes.dll / hermes-icu.dll that ship in the package.
+    CanRunTest: true
+    UseArm64Pool: true
 
 resources:
   repositories:
@@ -69,8 +80,13 @@ extends:
     settings:
       ${{ if eq(parameters.MustPublish, false) }}:
         skipBuildTagsForGitHubPullRequests: true
+      # fabric-internal-pool-large hosts several images, so the image must be
+      # named explicitly. windows-2025-1espt provides the Visual Studio 2026 and
+      # Clang toolset the build requires. Jobs inherit this pool unless they
+      # declare their own. See .ado/image/README.md.
     pool:
       name: fabric-internal-pool-large
+      demands: ImageOverride -equals windows-2025-1espt
     sdl:
       binskim:
         analyzeTarget: |
@@ -137,6 +153,15 @@ extends:
 
           timeoutInMinutes: 300
 
+          # Cells whose target architecture cannot run on an x64 agent build and
+          # test natively on the ARM64 managed-image pool. windows-2025-1espt-arm64
+          # is a single-image pool, so it takes no ImageOverride demand. All other
+          # cells inherit the top-level fabric-internal-pool-large pool, which
+          # pins the windows-2025-1espt image. See .ado/image/README.md.
+          ${{ if eq(MatrixEntry.UseArm64Pool, true) }}:
+            pool:
+              name: windows-2025-1espt-arm64
+
           variables:
           - name: semanticVersion
             value: $[ dependencies.Set_Versions.outputs['setVersions.semanticVersion'] ]
@@ -162,6 +187,13 @@ extends:
               targetPath: $(Build.StagingDirectory)\out\pkg-staging
 
           steps:
+            # ARM64 agents ship no externals\node10, but the mandatory 1ES
+            # build-retention post-job still runs on the Node 10 handler; shim
+            # node10 to the image's Node so that post-job does not fail. It must
+            # come first, before any work on the agent.
+          - ${{ if eq(MatrixEntry.UseArm64Pool, true) }}:
+            - template: /.ado/ensure-node10-shim.yml@self
+
             # Node.js version >= 22.x is required to handle args in JS scripts.
           - task: UseNode@1
             displayName: Use Node.js 22.x

--- a/.ado/build-template.yml
+++ b/.ado/build-template.yml
@@ -45,10 +45,8 @@ parameters:
     TargetCPU: arm64
     BuildUWP: --no-uwp
     CanRunTest: true
-    # ARM64 binaries cannot execute on an x64 agent: build.js would only
-    # cross-compile the shared libraries and skip every test. Run this cell on
-    # the native ARM64 pool instead. The UWP ARM64 cell stays on x64 - UWP
-    # binaries are not executed by the pipeline on any architecture.
+    # On an x64 agent build.js can only cross-compile the shared libraries and
+    # skips the tests. Flag per cell, not per TargetCPU, to keep uwp_arm64 on x64.
     UseArm64Pool: true
     # ARM64 "Emulation Compatible" is to run ARM64 Hermes DLL in a x64 app
     # on Windows ARM64 in emulation mode.
@@ -56,9 +54,8 @@ parameters:
   - Name: win32_arm64ec
     TargetCPU: arm64ec
     BuildUWP: --no-uwp
-    # ARM64EC code executes natively on Windows on ARM, so the ARM64 pool builds
-    # this cell as a native build: the test binaries are themselves ARM64EC and
-    # load the ARM64EC hermes.dll / hermes-icu.dll that ship in the package.
+    # ARM64EC runs natively on Windows on ARM, so the test binaries are ARM64EC
+    # too and exercise the ARM64EC DLLs that ship.
     CanRunTest: true
     UseArm64Pool: true
 
@@ -80,10 +77,8 @@ extends:
     settings:
       ${{ if eq(parameters.MustPublish, false) }}:
         skipBuildTagsForGitHubPullRequests: true
-      # fabric-internal-pool-large hosts several images, so the image must be
-      # named explicitly. windows-2025-1espt provides the Visual Studio 2026 and
-      # Clang toolset the build requires. Jobs inherit this pool unless they
-      # declare their own. See .ado/image/README.md.
+      # fabric-internal-pool-large hosts several images, so the one with VS 2026
+      # must be named explicitly. See .ado/image/README.md.
     pool:
       name: fabric-internal-pool-large
       demands: ImageOverride -equals windows-2025-1espt
@@ -130,9 +125,7 @@ extends:
           value: ${{ parameters.MustPublish }}
 
         steps:
-          # Node.js >= 22 is required to handle args in JS scripts. Use 24.x: it is
-          # the version installed on the build images, so the task resolves it
-          # locally instead of downloading a different one.
+          # 24.x is the version installed on the build images.
         - task: UseNode@1
           displayName: Use Node.js 24.x
           inputs:
@@ -155,11 +148,7 @@ extends:
 
           timeoutInMinutes: 300
 
-          # Cells whose target architecture cannot run on an x64 agent build and
-          # test natively on the ARM64 managed-image pool. windows-2025-1espt-arm64
-          # is a single-image pool, so it takes no ImageOverride demand. All other
-          # cells inherit the top-level fabric-internal-pool-large pool, which
-          # pins the windows-2025-1espt image. See .ado/image/README.md.
+          # Single-image pool, so no ImageOverride demand.
           ${{ if eq(MatrixEntry.UseArm64Pool, true) }}:
             pool:
               name: windows-2025-1espt-arm64
@@ -189,16 +178,11 @@ extends:
               targetPath: $(Build.StagingDirectory)\out\pkg-staging
 
           steps:
-            # ARM64 agents ship no externals\node10, but the mandatory 1ES
-            # build-retention post-job still runs on the Node 10 handler; shim
-            # node10 to the image's Node so that post-job does not fail. It must
-            # come first, before any work on the agent.
+            # Must run before anything else on the agent - see the template.
           - ${{ if eq(MatrixEntry.UseArm64Pool, true) }}:
             - template: /.ado/ensure-node10-shim.yml@self
 
-            # Node.js >= 22 is required to handle args in JS scripts. Use 24.x:
-            # it is the version installed on the build images, so the task
-            # resolves it locally instead of downloading a different one.
+            # 24.x is the version installed on the build images.
           - task: UseNode@1
             displayName: Use Node.js 24.x
             inputs:
@@ -218,9 +202,10 @@ extends:
             displayName: Build binaries
 
             # Show all built files to help debug issues.
-          - script: |
-              ls -R $(Build.StagingDirectory)\out
-            displayName: Show all files in the $$(Build.StagingDirectory)\out directory
+          - pwsh: |
+              Get-ChildItem -LiteralPath "$(Build.StagingDirectory)\out" -Recurse |
+                Select-Object -ExpandProperty FullName
+            displayName: Show all staged files
 
             # Run unit tests after the build is finished.
           - ${{ if eq(MatrixEntry.CanRunTest, true) }}:
@@ -344,9 +329,7 @@ extends:
             artifactName: published-packages
 
         steps:
-          # Node.js >= 22 is required to handle args in JS scripts. Use 24.x: it is
-          # the version installed on the build images, so the task resolves it
-          # locally instead of downloading a different one.
+          # 24.x is the version installed on the build images.
         - task: UseNode@1
           displayName: Use Node.js 24.x
           inputs:

--- a/.ado/build-template.yml
+++ b/.ado/build-template.yml
@@ -130,11 +130,13 @@ extends:
           value: ${{ parameters.MustPublish }}
 
         steps:
-          # Node.js version >= 22.x is required to handle args in JS scripts.
+          # Node.js >= 22 is required to handle args in JS scripts. Use 24.x: it is
+          # the version installed on the build images, so the task resolves it
+          # locally instead of downloading a different one.
         - task: UseNode@1
-          displayName: Use Node.js 22.x
+          displayName: Use Node.js 24.x
           inputs:
-            version: 22.x
+            version: 24.x
 
           # Compute the semanticVersion and fileVersion, and then update the build title.
         - script: node .ado\scripts\setVersionNumber.js
@@ -194,11 +196,13 @@ extends:
           - ${{ if eq(MatrixEntry.UseArm64Pool, true) }}:
             - template: /.ado/ensure-node10-shim.yml@self
 
-            # Node.js version >= 22.x is required to handle args in JS scripts.
+            # Node.js >= 22 is required to handle args in JS scripts. Use 24.x:
+            # it is the version installed on the build images, so the task
+            # resolves it locally instead of downloading a different one.
           - task: UseNode@1
-            displayName: Use Node.js 22.x
+            displayName: Use Node.js 24.x
             inputs:
-              version: 22.x
+              version: 24.x
 
             # Invoke the build specific for the target platform.
           - script: >
@@ -340,11 +344,13 @@ extends:
             artifactName: published-packages
 
         steps:
-          # Node.js version >= 22.x is required to handle args in JS scripts.
+          # Node.js >= 22 is required to handle args in JS scripts. Use 24.x: it is
+          # the version installed on the build images, so the task resolves it
+          # locally instead of downloading a different one.
         - task: UseNode@1
-          displayName: Use Node.js 22.x
+          displayName: Use Node.js 24.x
           inputs:
-            version: 22.x
+            version: 24.x
 
           # The substitution tags in the nuspec require that we use at least NuGet 4.6.
         - task: NuGetToolInstaller@0

--- a/.ado/ensure-node10-shim.yml
+++ b/.ado/ensure-node10-shim.yml
@@ -1,0 +1,41 @@
+# Workaround for the 1ES "Retain Build Artifacts"
+# (BuildArtifactRetentionPolicyTask@1) post-job, which targets the Node 10 task
+# handler. Recent agents (>= 5.276) no longer ship `externals\node10`, and the
+# ARM64 agent has none at all, so the mandatory retention post-job fails with:
+#   "This step requires a node version that does not exist in the agent
+#    filesystem. Path: ...\externals\node10\bin\node.exe"
+#
+# This shims node10 to the image's installed Node.js (the image installs Node 24
+# at C:\Program Files\nodejs), falling back to the agent's own bundled node if
+# that is ever absent. Azure Pipelines task handlers are forward-compatible in
+# practice (node6->10->16->20), and the retention task is simple. If a future
+# task genuinely needs a real node10, we would instead bake node10 into the image.
+#
+# Reference it from a job's steps BEFORE its work so node10 exists by the time
+# the post-job runs on the same agent.
+steps:
+- powershell: |
+    $ErrorActionPreference = 'Stop'
+    $ext = Join-Path $env:AGENT_HOMEDIRECTORY 'externals'
+    $node10Exe = Join-Path $ext 'node10\bin\node.exe'
+    if (Test-Path $node10Exe) {
+        Write-Host "node10 already present: $node10Exe"
+    } else {
+        # Prefer the image's Node.js (the image installs Node 24); fall back to
+        # the agent's own bundled node.
+        $srcExe = @(
+            (Join-Path $env:ProgramFiles 'nodejs\node.exe'),
+            (Join-Path $ext 'node\bin\node.exe')
+        ) | Where-Object { Test-Path $_ } | Select-Object -First 1
+        if (-not $srcExe) { throw "No Node.js found to shim node10 (checked Program Files\nodejs and agent externals\node)." }
+        Write-Host "Shimming node10 -> $srcExe"
+        New-Item -ItemType Directory -Force -Path (Split-Path $node10Exe) | Out-Null
+        try {
+            New-Item -ItemType SymbolicLink -Path $node10Exe -Target $srcExe -ErrorAction Stop | Out-Null
+        } catch {
+            Write-Warning "Symlink failed ($($_.Exception.Message)); copying instead."
+            Copy-Item $srcExe $node10Exe -Force
+        }
+        & $node10Exe --version
+    }
+  displayName: Shim node10 handler (agent lacks externals\node10)

--- a/.ado/ensure-node10-shim.yml
+++ b/.ado/ensure-node10-shim.yml
@@ -1,28 +1,17 @@
-# Workaround for the 1ES "Retain Build Artifacts"
-# (BuildArtifactRetentionPolicyTask@1) post-job, which targets the Node 10 task
-# handler. Recent agents (>= 5.276) no longer ship `externals\node10`, and the
-# ARM64 agent has none at all, so the mandatory retention post-job fails with:
-#   "This step requires a node version that does not exist in the agent
-#    filesystem. Path: ...\externals\node10\bin\node.exe"
+# The mandatory 1ES "Retain Build Artifacts" post-job runs on the Node 10 task
+# handler, but recent agents no longer ship `externals\node10` (ARM64 agents
+# never did), so it fails with "This step requires a node version that does not
+# exist in the agent filesystem". Point node10 at the image's Node instead.
 #
-# This shims node10 to the image's installed Node.js (the image installs Node 24
-# at C:\Program Files\nodejs), falling back to the agent's own bundled node if
-# that is ever absent. Azure Pipelines task handlers are forward-compatible in
-# practice (node6->10->16->20), and the retention task is simple. If a future
-# task genuinely needs a real node10, we would instead bake node10 into the image.
-#
-# Reference it from a job's steps BEFORE its work so node10 exists by the time
-# the post-job runs on the same agent.
+# Reference this BEFORE a job's work, so node10 exists when the post-job runs.
 steps:
-- powershell: |
+- pwsh: |
     $ErrorActionPreference = 'Stop'
     $ext = Join-Path $env:AGENT_HOMEDIRECTORY 'externals'
     $node10Exe = Join-Path $ext 'node10\bin\node.exe'
     if (Test-Path $node10Exe) {
         Write-Host "node10 already present: $node10Exe"
     } else {
-        # Prefer the image's Node.js (the image installs Node 24); fall back to
-        # the agent's own bundled node.
         $srcExe = @(
             (Join-Path $env:ProgramFiles 'nodejs\node.exe'),
             (Join-Path $ext 'node\bin\node.exe')

--- a/.ado/image/README.md
+++ b/.ado/image/README.md
@@ -1,0 +1,53 @@
+# CI/PR VM images
+
+The Azure DevOps pipelines in this folder run on **1ES managed images** that are
+shared with [microsoft/v8-jsi](https://github.com/microsoft/v8-jsi). The image
+definitions — the ordered lists of provisioning artifacts that produce each image
+— live there and are the single source of truth:
+
+<https://github.com/microsoft/v8-jsi/tree/master/.ado/image>
+
+They are intentionally **not** duplicated here: two copies of the same JSON would
+drift, and only one of them can be the one that is actually built. Change the
+image in v8-jsi; hermes-windows picks up the result automatically because the
+pipelines select an image by name, not by version.
+
+Both images carry the same toolchain — **Visual Studio 2026 Enterprise with
+Clang, the current Windows SDK, Node.js 24, Python and .NET 10** — so x64, x86,
+ARM64 and ARM64EC all build and test with the same tools.
+
+## Pool to image mapping
+
+| Cells | Pool | Image | How the image is selected |
+|---|---|---|---|
+| `win32_x64`, `win32_x86`, all `uwp_*` | `fabric-internal-pool-large` | `windows-2025-1espt` | `demands: ImageOverride -equals windows-2025-1espt` |
+| `win32_arm64`, `win32_arm64ec` | `windows-2025-1espt-arm64` | `windows-2025-1espt-arm64` | none — single-image pool |
+
+`fabric-internal-pool-large` hosts several images, so the image **must** be named
+with an `ImageOverride` demand. This is set once on the top-level `pool:` in
+[`build-template.yml`](../build-template.yml) and inherited by every job that
+does not declare its own pool.
+
+`windows-2025-1espt-arm64` is a **single-image pool** — its one default image is
+`windows-2025-1espt-arm64` — so it takes no `ImageOverride` demand, and adding
+one would only risk breaking agent matching.
+
+## Why ARM64 and ARM64EC run on their own pool
+
+ARM64 and ARM64EC code cannot execute on an x64 agent. On an x64 host
+`.ado/scripts/build.js` treats both as cross builds: it builds only the shared
+libraries and skips the test run entirely. On the native ARM64 pool both are
+host-native, so the full target set (tools, unit-test binaries, lit drivers)
+builds and the C++ unit tests, the JS regression tests and the Test262 Intl
+tests all run against the binaries that actually ship.
+
+ARM64EC binaries run natively on Windows on ARM as well, and the ARM64EC test
+executables are themselves ARM64EC, so they exercise the shipped ARM64EC
+`hermes.dll` / `hermes-icu.dll` the way a real consumer would.
+
+## Updating an image
+
+Edit the JSON in v8-jsi and trigger a managed-image rebuild there. A branch edit
+alone changes nothing: a pipeline run always uses the currently *published*
+image, and rebuilding plus replicating one takes hours. Rebuild the image before
+relying on a new tool or environment variable in a pipeline step here.

--- a/.ado/scripts/build.js
+++ b/.ado/scripts/build.js
@@ -1259,13 +1259,18 @@ function setupJSTestEnvPaths() {
 
   // Helper function to find executable path using 'where'
   function findExecutable(name) {
+    return findExecutables(name)[0] ?? null;
+  }
+
+  // The 'where' command returns a list of paths, one per line.
+  function findExecutables(name) {
     try {
-      // The 'where' command returns a list of paths, one per line. We want the first one.
-      const output = execSync(`where ${name}`, { encoding: "utf8" });
-      const firstPath = output.split("\r\n")[0];
-      return firstPath ? path.dirname(firstPath) : null;
+      return execSync(`where ${name}`, { encoding: "utf8" })
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .map((exePath) => path.dirname(exePath));
     } catch {
-      return null;
+      return [];
     }
   }
 
@@ -1273,19 +1278,24 @@ function setupJSTestEnvPaths() {
     console.warn(`Warning: ${message}`);
   }
 
-  // Add Git Bash to PATH for LIT tests
+  // Add Git Bash to PATH for LIT tests. The build agent's own bundled Git has
+  // no bash.exe, so consider every Git on PATH plus the default install dirs.
   (function () {
-    const gitDir = findExecutable("git.exe");
-    if (!gitDir) {
-      return showWarning("Git (git.exe) not found in PATH.");
+    const candidates = [
+      ...findExecutables("git.exe").map((dir) =>
+        path.join(path.dirname(dir), "bin"),
+      ),
+      path.join(process.env.ProgramFiles ?? "", "Git", "bin"),
+      path.join(process.env["ProgramFiles(x86)"] ?? "", "Git", "bin"),
+    ];
+    const gitBashDir = candidates.find((dir) =>
+      fs.existsSync(path.join(dir, "bash.exe")),
+    );
+    if (!gitBashDir) {
+      return showWarning("Git Bash (bash.exe) not found. LIT tests require it.");
     }
-    console.log(`Found Git at: ${gitDir}`);
-    const gitBashDir = gitDir.replace("cmd", "bin");
-    if (!fs.existsSync(path.join(gitBashDir, "bash.exe"))) {
-      return showWarning(`Git Bash (bash.exe) not found at: ${gitBashDir}`);
-    }
+    console.log(`Found Git Bash at: ${gitBashDir}`);
     if (!process.env.PATH.includes(gitBashDir)) {
-      console.log(`Adding Git Bash directory to PATH: ${gitBashDir}`);
       process.env.PATH = `${gitBashDir};${process.env.PATH}`;
     }
   })();

--- a/.ado/scripts/build.js
+++ b/.ado/scripts/build.js
@@ -121,7 +121,6 @@ Options:
   --msvc                  Use MSVC compiler instead of Clang (default: ${
     options.msvc.default
   })
-                          [Note: ARM64EC temporarily uses MSVC due to Clang 19.x issue]
   --uwp                   Build for UWP instead of Win32 (default: ${
     options.uwp.default
   })
@@ -217,11 +216,12 @@ const externalIcuVersion = 78;
 
 // BinSkim security validation constants.
 // The CI pipeline uses the internal package (Microsoft.CodeAnalysis.BinSkim.Internal)
-// from a private ADO feed. For local builds we use the public nuget.org package
-// which contains the same analysis engine.
+// from a private ADO feed. For local builds we use the public ADO feed, which
+// serves the same analysis engine and keeps us off the public NuGet API.
 const binskimPackageName = "Microsoft.CodeAnalysis.BinSkim";
 const binskimVersion = "4.4.9";
-const binskimNuGetSource = "https://api.nuget.org/v3/index.json";
+const binskimNuGetSource =
+  "https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json";
 
 main();
 
@@ -230,10 +230,6 @@ function main() {
 
   ensureDir(args["output-path"]);
   args["output-path"] = path.resolve(args["output-path"]);
-
-  // Force MSVC for ARM64EC due to Clang 19.x linker issues (LLVM #113658)
-  // This must be removed when Clang 20 is available
-  const useMsvc = args.msvc || args.platform.includes("arm64ec");
 
   args.hostCpuArch = getHostCpuArch();
 
@@ -251,7 +247,6 @@ function main() {
   console.log(`          clean-tools: ${args["clean-tools"]}`);
   console.log(`            clean-pkg: ${args["clean-pkg"]}`);
   console.log(`                 msvc: ${args.msvc}`);
-  console.log(`              useMsvc: ${useMsvc}`);
   console.log(`                  uwp: ${args.uwp}`);
   console.log(`             platform: ${args.platform}`);
   console.log(`        configuration: ${args.configuration}`);
@@ -309,7 +304,7 @@ function main() {
       };
       const buildParams = {
         ...configParams,
-        msvc: useMsvc,
+        msvc: args.msvc,
         buildPath: getBuildPath(configParams),
         hasCustomTargets: args.targets.length > 0,
         targets: getTargets(args.targets, configParams),
@@ -478,8 +473,11 @@ function cmakeConfigure(buildParams) {
     genArgs.push(`-DHERMES_FILE_VERSION=${args["file-version"]}`);
   }
 
-  // Add cross-compilation target for non-host platforms when using Clang
-  if (platform !== hostCpuArch && !msvc) {
+  // Select the Clang target triple. This is needed whenever the target differs
+  // from the host, and additionally always for ARM64EC: even on an ARM64 host,
+  // Clang's default target is plain ARM64, so the EC target must be requested
+  // explicitly.
+  if (!msvc && (platform !== hostCpuArch || platform === "arm64ec")) {
     let targetTriple = "";
     if (platform === "x86") {
       targetTriple = "i686-pc-windows-msvc";
@@ -552,15 +550,29 @@ function cmakeConfigure(buildParams) {
   // this via CMAKE_C_FLAGS, but shermes uses its own SHERMES_CC_SYSCFLAGS.
   // This applies regardless of the main compiler (Clang or MSVC) because
   // shermes always invokes clang to compile generated C code.
-  if (platform !== hostCpuArch) {
+  // ARM64EC always needs the triple, even on an ARM64 host: Clang's default
+  // target there is plain ARM64, and non-EC objects cannot link against
+  // ARM64EC output.
+  if (platform !== hostCpuArch || platform === "arm64ec") {
     let shermesTarget = "";
     if (platform === "x86") {
       shermesTarget = "i686-pc-windows-msvc";
     } else if (platform === "arm64") {
       shermesTarget = "aarch64-pc-windows-msvc";
+    } else if (platform === "arm64ec") {
+      shermesTarget = "arm64ec-pc-windows-msvc";
     }
     if (shermesTarget) {
       genArgs.push(`-DSHERMES_CC_SYSCFLAGS="-target ${shermesTarget}"`);
+    }
+    // ARM64EC additionally needs softintrin.lib at link time. The C code that
+    // shermes generates and links pulls in the UCRT floating-point helpers
+    // (_fenvutils/ieee), which reference the x64 SSE intrinsics _mm_getcsr /
+    // _mm_setcsr; on ARM64EC those are provided by softintrin.lib. This goes in
+    // SHERMES_CC_SYSLDFLAGS (linker flags) rather than SHERMES_CC_SYSCFLAGS,
+    // since shermes only applies it when it links an executable/shared object.
+    if (platform === "arm64ec") {
+      genArgs.push('-DSHERMES_CC_SYSLDFLAGS="-lsoftintrin"');
     }
   }
 
@@ -675,10 +687,13 @@ function cmakeBuildHermesCompiler(buildParams) {
 }
 
 function runCMakeCommand(command, buildParams) {
-  const { platform, buildPath } = buildParams;
+  const { platform, msvc, buildPath } = buildParams;
 
   const env = { ...process.env };
-  if (platform === "arm64ec") {
+  // MSVC needs an explicit switch to emit ARM64EC code; Clang selects it
+  // through the arm64ec-pc-windows-msvc target triple instead (see
+  // cmakeConfigure), and rejects the MSVC spelling.
+  if (platform === "arm64ec" && msvc) {
     env.CFLAGS = "-arm64EC";
     env.CXXFLAGS = "-arm64EC";
   }
@@ -929,6 +944,10 @@ function packNuGet(runParams) {
   execSync(fatNugetPackCmd, { stdio: "inherit" });
 }
 
+// Locate vcvarsall.bat from the installed Visual Studio.
+// Visual Studio 2026 (product version 18) is required: it provides the MSVC
+// 14.5x toolset and the Clang 22 that this repo builds with, and it is the
+// toolset installed on the CI images. VS 2022 is not supported.
 function getVCVarsAllBat() {
   const vsWhere = path.join(
     process.env["ProgramFiles(x86)"] || process.env["ProgramFiles"],
@@ -941,11 +960,11 @@ function getVCVarsAllBat() {
   }
 
   const versionJson = JSON.parse(
-    execSync(`"${vsWhere}" -format json -version 17`).toString(),
+    execSync(`"${vsWhere}" -format json -version 18`).toString(),
   );
   if (versionJson.length === 0) {
     throw new Error(
-      `No Visual Studio 2022 (version 17) installation found by vswhere: "${vsWhere}"`,
+      `No Visual Studio 2026 (version 18) installation found by vswhere: "${vsWhere}"`,
     );
   }
   if (versionJson.length > 1) {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,21 @@ script. Use the `.\dev` PowerShell wrapper from the repository root.
 - `x64` (default) — uses Clang
 - `x86` — uses Clang
 - `arm64` — uses Clang
-- `arm64ec` — uses MSVC (Clang not supported yet)
+- `arm64ec` — uses Clang
+
+All Windows targets build with the Clang that ships in Visual Studio 2026; pass
+`--msvc` to use MSVC instead. Visual Studio 2026 is required (the build script
+locates it with `vswhere -version 18`).
+
+ARM64EC has two toolchain quirks worth knowing:
+
+- It advertises the x64 predefined macros (`__x86_64__`, `_M_X64`, `__SSE2__`,
+  ...) so that x64-targeting source keeps compiling, but Clang generates AArch64
+  code and provides no x86 intrinsics. Code guarded on those macros must also
+  check `!defined(__arm64ec__)`; the NEON path is the right one there.
+- It links `softintrin.lib` (added in `HermesWindows.cmake`) for the x64
+  intrinsics the UCRT references. Without it every link fails with
+  `undefined symbol: _mm_getcsr (EC symbol)`.
 
 ### Build Options
 
@@ -124,6 +138,19 @@ The main build script is `.ado/scripts/build.js`. It handles:
 - Visual Studio environment setup via `vcvarsall.bat`
 - CMake configuration with correct flags per platform
 - Building, testing, packaging, and BinSkim validation
+
+### Continuous Integration
+
+`.ado/build-template.yml` drives both the PR and the CI pipelines. x64, x86 and
+all UWP cells run on the x64 agent image; the `win32_arm64` and `win32_arm64ec`
+cells run on a native ARM64 agent pool so that they build the full target set and
+run their tests instead of only cross-compiling the shared libraries. Both
+architectures run the C++ unit tests, the JS regression tests and the Test262
+Intl tests. See `.ado/image/README.md` for the pool and image mapping.
+
+Because those cells are native builds, they also stage `hermes.exe` and
+`hermesc.exe`, so the NuGet package now carries the tools for every target
+platform instead of only x64 and x86.
 
 ## Code Architecture
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -54,10 +54,10 @@
       }
     },
     {
-      "name": "base-vs2022-msvc",
+      "name": "base-vs2026-msvc",
       "hidden": true,
       "inherits": "base-common",
-      "generator": "Visual Studio 17 2022"
+      "generator": "Visual Studio 18 2026"
     },
     {
       "name": "ninja-clang-debug",
@@ -100,11 +100,11 @@
       }
     },
     {
-      "name": "vs2022-msvc-x64",
-      "inherits": "base-vs2022-msvc",
-      "displayName": "Visual Studio 2022 + MSVC (x64)",
-      "description": "Visual Studio 2022 generator with MSVC toolset (x64)",
-      "binaryDir": "${sourceDir}/build/vs2022-msvc-x64",
+      "name": "vs2026-msvc-x64",
+      "inherits": "base-vs2026-msvc",
+      "displayName": "Visual Studio 2026 + MSVC (x64)",
+      "description": "Visual Studio 2026 generator with MSVC toolset (x64)",
+      "binaryDir": "${sourceDir}/build/vs2026-msvc-x64",
       "architecture": {
         "value": "x64",
         "strategy": "set"
@@ -117,11 +117,11 @@
       }
     },
     {
-      "name": "vs2022-msvc-x86",
-      "inherits": "base-vs2022-msvc",
-      "displayName": "Visual Studio 2022 + MSVC (x86)",
-      "description": "Visual Studio 2022 generator with MSVC toolset (x86)",
-      "binaryDir": "${sourceDir}/build/vs2022-msvc-x86",
+      "name": "vs2026-msvc-x86",
+      "inherits": "base-vs2026-msvc",
+      "displayName": "Visual Studio 2026 + MSVC (x86)",
+      "description": "Visual Studio 2026 generator with MSVC toolset (x86)",
+      "binaryDir": "${sourceDir}/build/vs2026-msvc-x86",
       "architecture": {
         "value": "x86",
         "strategy": "set"
@@ -134,11 +134,11 @@
       }
     },
     {
-      "name": "vs2022-msvc-arm64",
-      "inherits": "base-vs2022-msvc",
-      "displayName": "Visual Studio 2022 + MSVC (ARM64)",
-      "description": "Visual Studio 2022 generator with MSVC toolset (ARM64)",
-      "binaryDir": "${sourceDir}/build/vs2022-msvc-arm64",
+      "name": "vs2026-msvc-arm64",
+      "inherits": "base-vs2026-msvc",
+      "displayName": "Visual Studio 2026 + MSVC (ARM64)",
+      "description": "Visual Studio 2026 generator with MSVC toolset (ARM64)",
+      "binaryDir": "${sourceDir}/build/vs2026-msvc-arm64",
       "architecture": {
         "value": "ARM64",
         "strategy": "set"
@@ -156,11 +156,11 @@
     { "name": "ninja-clang-release", "configurePreset": "ninja-clang-release" },
     { "name": "ninja-msvc-debug", "configurePreset": "ninja-msvc-debug" },
     { "name": "ninja-msvc-release", "configurePreset": "ninja-msvc-release" },
-    { "name": "vs2022-msvc-x64-debug", "configurePreset": "vs2022-msvc-x64", "configuration": "Debug" },
-    { "name": "vs2022-msvc-x64-release", "configurePreset": "vs2022-msvc-x64", "configuration": "Release" },
-    { "name": "vs2022-msvc-x86-debug", "configurePreset": "vs2022-msvc-x86", "configuration": "Debug" },
-    { "name": "vs2022-msvc-x86-release", "configurePreset": "vs2022-msvc-x86", "configuration": "Release" },
-    { "name": "vs2022-msvc-arm64-debug", "configurePreset": "vs2022-msvc-arm64", "configuration": "Debug" },
-    { "name": "vs2022-msvc-arm64-release", "configurePreset": "vs2022-msvc-arm64", "configuration": "Release" }
+    { "name": "vs2026-msvc-x64-debug", "configurePreset": "vs2026-msvc-x64", "configuration": "Debug" },
+    { "name": "vs2026-msvc-x64-release", "configurePreset": "vs2026-msvc-x64", "configuration": "Release" },
+    { "name": "vs2026-msvc-x86-debug", "configurePreset": "vs2026-msvc-x86", "configuration": "Debug" },
+    { "name": "vs2026-msvc-x86-release", "configurePreset": "vs2026-msvc-x86", "configuration": "Release" },
+    { "name": "vs2026-msvc-arm64-debug", "configurePreset": "vs2026-msvc-arm64", "configuration": "Debug" },
+    { "name": "vs2026-msvc-arm64-release", "configurePreset": "vs2026-msvc-arm64", "configuration": "Release" }
   ]
 }

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <!-- We must use ADO feed to be compliant. -->
+    <add key="react-native-public" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>

--- a/cmake/modules/HermesWindows.cmake
+++ b/cmake/modules/HermesWindows.cmake
@@ -236,6 +236,21 @@ function(hermes_windows_configure_build)
     set(HERMES_MSVC_ARM64 ON)
   endif()
 
+  # ARM64EC code can reference x64 SSE intrinsics that the ARM64 CPU cannot
+  # execute directly -- for example _mm_getcsr / _mm_setcsr, which the UCRT
+  # floating-point environment code (_fenvutils.obj, ieee.obj) uses. Those are
+  # emulated by softintrin.lib. MSVC emits a /DEFAULTLIB:softintrin directive
+  # for ARM64EC automatically; Clang does not, so link the library explicitly,
+  # otherwise every link fails with "undefined symbol: _mm_getcsr (EC symbol)".
+  # This goes into CMAKE_*_LINKER_FLAGS rather than HERMES_EXTRA_LINKER_FLAGS
+  # so that CMake's configure-time try_compile checks (for example llvh's
+  # CheckAtomic) link as well.
+  if(HERMES_WINDOWS_TARGET_PLATFORM STREQUAL "arm64ec" AND
+     "${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lsoftintrin")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lsoftintrin")
+  endif()
+
   # Configure compiler flags
   if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
     hermes_windows_configure_clang_flags()
@@ -252,6 +267,8 @@ function(hermes_windows_configure_build)
   
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}" PARENT_SCOPE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" PARENT_SCOPE)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}" PARENT_SCOPE)
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}" PARENT_SCOPE)
   set(HERMES_EXTRA_LINKER_FLAGS "${HERMES_EXTRA_LINKER_FLAGS}" PARENT_SCOPE)
 
   message(STATUS "Hermes Windows build configuration complete")

--- a/doc/DebugWindowsMemoryIssues.md
+++ b/doc/DebugWindowsMemoryIssues.md
@@ -164,7 +164,7 @@ For applications that spawn child processes (like NodeApiTests.exe → node-lite
       "name": "Debug NodeApiTests with Child Processes",
       "type": "cppvsdbg",
       "request": "launch",
-      "program": "${workspaceFolder}/build/vs2022-msvc-x64/unittests/NodeApi/Debug/NodeApiTests.exe",
+      "program": "${workspaceFolder}/build/vs2026-msvc-x64/unittests/NodeApi/Debug/NodeApiTests.exe",
       "args": ["--gtest_output=xml:${workspaceFolder}/test-results.xml"],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}",

--- a/doc/HermesWindowsFork.md
+++ b/doc/HermesWindowsFork.md
@@ -145,11 +145,23 @@ When adding or modifying Windows-specific features:
   - Git for Windows
   - Powershell 7 (included in azure devbox)
     - `winget install Microsoft.Powershell` to install if not present
-  - Visual Studio 2026, but currently using v143 build tools
-    - Open vsinstaller, click `modify` in 2026 followed by `individual components`, install in total 4 packages:
-      - C++ AST for latest v143 build tools with Spectre Mitigation (ARM64)/(x86 & x64)
-      - MSVC v143 - VS 2022 C++ ARM64/ARM64EC//x64/x86 Spectre-mitigated libs
-      - After upgrading to v145 package names are completely different
+  - Visual Studio 2026 (required; Visual Studio 2022 is not supported)
+    - The build script locates Visual Studio with `vswhere -version 18` and uses
+      its MSVC 14.5x toolset and bundled Clang 22.
+    - Open vsinstaller, click `modify` on 2026 followed by `individual components`
+      and install, in addition to the C++ desktop workload:
+      - `C++ Clang Compiler for Windows`
+        (`Microsoft.VisualStudio.Component.VC.Llvm.Clang`)
+      - `MSBuild support for LLVM (clang-cl) toolset`
+        (`Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset`)
+      - MSVC ARM64 build tools
+        (`Microsoft.VisualStudio.Component.VC.Tools.ARM64`)
+      - Spectre-mitigated runtime libraries for every target you build
+        (`...VC.Runtimes.x86.x64.Spectre`, `...VC.Runtimes.ARM64.Spectre`,
+        `...VC.Runtimes.ARM64EC.Spectre`) — the build script always passes
+        `-vcvars_spectre_libs=spectre`
+      - C++ ATL with Spectre mitigations (`...VC.ATL.Spectre`,
+        `...VC.ATL.ARM64.Spectre`)
   - Visual Studio Code
     - Install `CMake Tools` (by Microsoft) and `C++ TestMate`
 

--- a/external/ExternalDependenciesSummary.md
+++ b/external/ExternalDependenciesSummary.md
@@ -143,7 +143,7 @@ To update any external dependency:
 
 3. **Test compilation**:
    ```powershell
-   cd ../../build/vs2022-msvc-x64
+   cd ../../build/vs2026-msvc-x64
    cmake --build . --target hermesinspector
    ```
 

--- a/external/boost/boost_1_86_0/hoost/context/fiber_winfib.hpp
+++ b/external/boost/boost_1_86_0/hoost/context/fiber_winfib.hpp
@@ -220,16 +220,20 @@ public:
 
     void run() {
         Ctx c{ from };
+#ifndef BOOST_NO_EXCEPTIONS
         try {
+#endif
             // invoke context-function
 #if defined(BOOST_NO_CXX17_STD_INVOKE)
             c = boost::context::detail::invoke( fn_, std::move( c) );
 #else
             c = std::invoke( fn_, std::move( c) );
 #endif
+#ifndef BOOST_NO_EXCEPTIONS
         } catch ( forced_unwind const& ex) {
             c = Ctx{ ex.from };
         }
+#endif
         // this context has finished its task
         from = nullptr;
         ontop = nullptr;
@@ -352,7 +356,11 @@ public:
         detail::fiber_activation_record * ptr = std::exchange( ptr_, nullptr)->resume();
 #endif
         if ( BOOST_UNLIKELY( detail::fiber_activation_record::current()->force_unwind) ) {
+#ifdef BOOST_NO_EXCEPTIONS
+            abort();
+#else
             throw detail::forced_unwind{ ptr};
+#endif
         } else if ( BOOST_UNLIKELY( nullptr != detail::fiber_activation_record::current()->ontop) ) {
             ptr = detail::fiber_activation_record::current()->ontop( ptr);
             detail::fiber_activation_record::current()->ontop = nullptr;
@@ -371,7 +379,11 @@ public:
             std::exchange( ptr_, nullptr)->resume_with< fiber >( std::forward< Fn >( fn) );
 #endif
         if ( BOOST_UNLIKELY( detail::fiber_activation_record::current()->force_unwind) ) {
+#ifdef BOOST_NO_EXCEPTIONS
+            abort();
+#else
             throw detail::forced_unwind{ ptr};
+#endif
         } else if ( BOOST_UNLIKELY( nullptr != detail::fiber_activation_record::current()->ontop) ) {
             ptr = detail::fiber_activation_record::current()->ontop( ptr);
             detail::fiber_activation_record::current()->ontop = nullptr;

--- a/external/dragonbox/dragonbox/dragonbox.h
+++ b/external/dragonbox/dragonbox/dragonbox.h
@@ -792,7 +792,7 @@ namespace JKJ_NAMESPACE {
                         low_ = stdr::uint_least64_t(result);
                         __builtin_ia32_addcarry_u64(carry, high_, 0, &result);
                         high_ = stdr::uint_least64_t(result);
-    #elif defined(_MSC_VER) && defined(_M_X64)
+    #elif defined(_MSC_VER) && defined(_M_X64) && !defined(__arm64ec__)
                         // On MSVC, uint_least64_t and __int64 must be unsigned long long; see
                         // https://learn.microsoft.com/en-us/cpp/c-runtime-library/standard-types
                         // and https://learn.microsoft.com/en-us/cpp/cpp/int8-int16-int32-int64.
@@ -871,7 +871,7 @@ namespace JKJ_NAMESPACE {
     #if defined(__SIZEOF_INT128__)
                     auto const result = builtin_uint128_t(x) * builtin_uint128_t(y);
                     return {stdr::uint_least64_t(result >> 64), stdr::uint_least64_t(result)};
-    #elif defined(_MSC_VER) && defined(_M_X64)
+    #elif defined(_MSC_VER) && defined(_M_X64) && !defined(__arm64ec__)
                     JKJ_IF_CONSTEVAL {
                         // This redundant variable is to workaround MSVC's codegen bug caused by the
                         // interaction of NRVO and intrinsics.

--- a/external/folly/src/folly/Portability.h
+++ b/external/folly/src/folly/Portability.h
@@ -328,7 +328,13 @@ constexpr auto kIsBigEndian = !kIsLittleEndian;
 } // namespace folly
 
 #ifndef FOLLY_SSE
-#if defined(__SSE4_2__)
+// ARM64EC advertises the x64 feature macros (__x86_64__, __SSE2__, ...) so that
+// x64-targeting source keeps compiling, but Clang generates AArch64 code there
+// and provides no x86 intrinsics. Report no SSE and use the NEON paths below.
+#if defined(__arm64ec__)
+#define FOLLY_SSE 0
+#define FOLLY_SSE_MINOR 0
+#elif defined(__SSE4_2__)
 #define FOLLY_SSE 4
 #define FOLLY_SSE_MINOR 2
 #elif defined(__SSE4_1__)
@@ -356,7 +362,7 @@ constexpr auto kIsBigEndian = !kIsLittleEndian;
   (FOLLY_SSE > major || FOLLY_SSE == major && FOLLY_SSE_MINOR >= minor)
 
 #ifndef FOLLY_NEON
-#if defined(__ARM_NEON) || defined(__ARM_NEON__)
+#if defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(__arm64ec__)
 #define FOLLY_NEON 1
 #endif
 #endif

--- a/external/folly/src/folly/portability/Asm.h
+++ b/external/folly/src/folly/portability/Asm.h
@@ -34,7 +34,11 @@ inline void asm_volatile_memory() {
 }
 
 inline void asm_volatile_pause() {
-#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
+// ARM64EC defines _M_X64 / FOLLY_X64 for x64 source compatibility, but the code
+// generated is AArch64, so emit the AArch64 "yield" rather than "pause".
+#if defined(__arm64ec__)
+  asm volatile("yield");
+#elif defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
   ::_mm_pause();
 #elif defined(__i386__) || FOLLY_X64 || (__mips_isa_rev > 1)
   asm volatile("pause");

--- a/external/llvh/lib/Support/Host.cpp
+++ b/external/llvh/lib/Support/Host.cpp
@@ -404,7 +404,11 @@ static bool isCpuIdSupported() {
 /// the specified arguments.  If we can't run cpuid on the host, return true.
 static bool getX86CpuIDAndInfo(unsigned value, unsigned *rEAX, unsigned *rEBX,
                                unsigned *rECX, unsigned *rEDX) {
-#if defined(__GNUC__) || defined(__clang__)
+// ARM64EC defines __x86_64__ so that x64-targeting source keeps compiling, but
+// the code generated is AArch64 and cannot use x86 register constraints or the
+// cpuid instruction. Fall through to the MSVC intrinsics, which ARM64EC
+// emulates.
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__arm64ec__)
 #if defined(__x86_64__)
   // gcc doesn't know cpuid would clobber ebx/rbx. Preserve it manually.
   // FIXME: should we save this for Clang?
@@ -444,7 +448,8 @@ static bool getX86CpuIDAndInfo(unsigned value, unsigned *rEAX, unsigned *rEBX,
 static bool getX86CpuIDAndInfoEx(unsigned value, unsigned subleaf,
                                  unsigned *rEAX, unsigned *rEBX, unsigned *rECX,
                                  unsigned *rEDX) {
-#if defined(__GNUC__) || defined(__clang__)
+// See the ARM64EC note in getX86CpuIDAndInfo above.
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__arm64ec__)
 #if defined(__x86_64__)
   // gcc doesn't know cpuid would clobber ebx/rbx. Preserve it manually.
   // FIXME: should we save this for Clang?
@@ -479,7 +484,8 @@ static bool getX86CpuIDAndInfoEx(unsigned value, unsigned subleaf,
 
 // Read control register 0 (XCR0). Used to detect features such as AVX.
 static bool getX86XCR0(unsigned *rEAX, unsigned *rEDX) {
-#if defined(__GNUC__) || defined(__clang__)
+// See the ARM64EC note in getX86CpuIDAndInfo above.
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__arm64ec__)
   // Check xgetbv; this uses a .byte sequence instead of the instruction
   // directly because older assemblers do not include support for xgetbv and
   // there is no easy way to conditionally compile based on the assembler used.

--- a/include/hermes/Support/SIMD.h
+++ b/include/hermes/Support/SIMD.h
@@ -12,8 +12,13 @@
 #pragma once
 
 // Determine which SIMD backend to use.
-#if (defined(__GNUC__) && defined(__aarch64__)) || \
-    (defined(_MSC_VER) && defined(_M_ARM64))
+// ARM64EC defines the x64 macros (__x86_64__ / _M_X64) so that x64-targeting
+// source keeps compiling, but Clang generates AArch64 code and does not provide
+// the x86 SSE builtins. ARM64EC runs on ARM64 hardware, so use NEON directly --
+// that is also faster than MSVC's emulated x64 intrinsics.
+#if (defined(__GNUC__) && defined(__aarch64__)) ||   \
+    (defined(_MSC_VER) && defined(_M_ARM64)) ||      \
+    (defined(__clang__) && defined(__arm64ec__))
 #define HERMES_SIMD_NEON
 #include <arm_neon.h>
 #elif (defined(__GNUC__) && defined(__x86_64__)) || \

--- a/include/hermes/VM/Profiler.h
+++ b/include/hermes/VM/Profiler.h
@@ -10,7 +10,9 @@
 
 #include <cstdint>
 
-#if defined(__i386__) || defined(__x86_64__)
+// ARM64EC advertises __x86_64__ so that x64-targeting source keeps compiling,
+// but Clang generates AArch64 code there and provides no x86 intrinsics.
+#if (defined(__i386__) || defined(__x86_64__)) && !defined(__arm64ec__)
 #include <x86intrin.h>
 #endif
 
@@ -20,7 +22,7 @@ namespace hermes {
     defined(HERMESVM_PROFILER_OPCODE) || defined(HERMESVM_PROFILER_NATIVECALL)
 
 inline uint64_t rdtsc() {
-#if defined(__i386__) || defined(__x86_64__)
+#if (defined(__i386__) || defined(__x86_64__)) && !defined(__arm64ec__)
   // Use the rdtsc intrinsic to get the cycle count if it's available.
   return __rdtsc();
 #elif defined(__aarch64__)

--- a/lib/VM/StaticH.cpp
+++ b/lib/VM/StaticH.cpp
@@ -117,6 +117,53 @@ extern "C" void _sh_raw_longjmp(jmp_buf, int) {
     "ret\n\t"
   );
 }
+
+#elif defined(_WIN32) && defined(_M_ARM64EC)
+// ARM64EC raw longjmp (Clang).
+//
+// ARM64EC runs AArch64 code but uses the x64 _JUMP_BUFFER layout: setjmp.h has
+// no _M_ARM64EC branch, and _M_ARM64EC also defines _M_X64, so jmp_buf is the
+// x64 SETJMP_FLOAT128[16] (256 bytes). setjmp maps to _setjmpex, whose ARM64EC
+// implementation stores the AArch64 callee-saved registers into the x64-named
+// slots per the fixed ARM64EC x64<->AArch64 register map:
+//   Rbx(+08)=x27  Rsp(+10)=sp   Rbp(+18)=fp/x29
+//   Rsi(+20)=x25  Rdi(+28)=x26
+//   R12(+30)=x19  R13(+38)=x20  R14(+40)=x21  R15(+48)=x22
+//   Rip(+50)=resume address     Xmm6-15(+60..+F0)=q6-q15 (callee-saved here)
+// x23/x24/x28 are never used by ARM64EC codegen, so they are not live across a
+// setjmp and need not be restored. The MxCsr slot (+58) is not restored: it is
+// an x64-format control word that cannot be loaded into AArch64 FPCR, and
+// Hermes never changes the FP control/rounding mode between setjmp and longjmp
+// (matching the minimal Linux _longjmp behavior).
+// ARM64EC calling convention (native AArch64 for intra-module calls):
+// x0=jmp_buf, w1=return_value.
+__attribute__((naked))
+extern "C" void _sh_raw_longjmp(jmp_buf, int) {
+  __asm__ volatile (
+    "mov x2, x0\n\t"
+    "mov w0, w1\n\t"
+    "cbnz w0, 1f\n\t"
+    "mov w0, #1\n"
+    "1:\n\t"
+    "ldr x27, [x2, #0x08]\n\t"       // Rbx
+    "ldr x29, [x2, #0x18]\n\t"       // Rbp -> fp
+    "ldr x25, [x2, #0x20]\n\t"       // Rsi
+    "ldr x26, [x2, #0x28]\n\t"       // Rdi
+    "ldr x19, [x2, #0x30]\n\t"       // R12
+    "ldr x20, [x2, #0x38]\n\t"       // R13
+    "ldr x21, [x2, #0x40]\n\t"       // R14
+    "ldr x22, [x2, #0x48]\n\t"       // R15
+    "ldp q6,  q7,  [x2, #0x60]\n\t"  // Xmm6,  Xmm7
+    "ldp q8,  q9,  [x2, #0x80]\n\t"  // Xmm8,  Xmm9
+    "ldp q10, q11, [x2, #0xA0]\n\t"  // Xmm10, Xmm11
+    "ldp q12, q13, [x2, #0xC0]\n\t"  // Xmm12, Xmm13
+    "ldp q14, q15, [x2, #0xE0]\n\t"  // Xmm14, Xmm15
+    "ldr x30, [x2, #0x50]\n\t"       // Rip -> resume address
+    "ldr x3,  [x2, #0x10]\n\t"       // Rsp
+    "mov sp,  x3\n\t"
+    "ret\n\t"
+  );
+}
 #endif
 
 using namespace hermes;
@@ -456,11 +503,15 @@ extern "C" void _sh_throw_current(SHRuntime *shr) {
     fprintf(stderr, "SH: uncaught exception");
     abort();
   }
-#if defined(_WIN32) && !defined(_M_ARM64EC) && \
-    (defined(_M_X64) || defined(_M_ARM64))
-  // On Windows x64/ARM64, the CRT's longjmp calls RtlUnwindEx to walk the
-  // stack through intermediate frames. This crashes when unwinding across DLL
-  // boundaries (e.g., from hermesvm.dll through a shermes-compiled DLL).
+#if defined(_WIN32) && \
+    (defined(_M_X64) || defined(_M_ARM64) || defined(_M_ARM64EC))
+  // On Windows x64/ARM64/ARM64EC, the CRT's longjmp calls RtlUnwindEx to walk
+  // the stack through intermediate frames. This crashes when unwinding across
+  // DLL boundaries (e.g., from hermesvm.dll through a shermes-compiled DLL); on
+  // ARM64EC it fails RtlUnwindEx's Control Flow Guard longjmp-target check
+  // (FAST_FAIL_INVALID_LONGJUMP_TARGET) because the loaded module's setjmp
+  // continuation is not in a CFG longjmp table when running inside a
+  // CFG-enforced host process.
   // Use a raw longjmp that directly restores registers and jumps, matching
   // Linux _longjmp behavior. This is safe because the VM manages its own
   // cleanup via _sh_catch, not SEH unwind handlers.

--- a/unittests/NodeApi/CMakeLists.txt
+++ b/unittests/NodeApi/CMakeLists.txt
@@ -26,6 +26,16 @@ function(add_node_api_module MODULE_TARGET)
   target_link_libraries(${MODULE_TARGET} PRIVATE libshared)
   target_compile_definitions(${MODULE_TARGET} PRIVATE ${ARG_DEFINES})
 
+  # These .node addons are MODULE libraries. Unlike the EXE/SHARED targets they
+  # do not pick up the softintrin.lib that HermesWindows adds to the linker
+  # flags (CMAKE_MODULE_LINKER_FLAGS does not reach this scope), so on ARM64EC
+  # they fail to link with "undefined symbol: _mm_getcsr (EC symbol)" -- an x64
+  # SSE intrinsic the UCRT floating-point code references. Link it per target.
+  if(HERMES_WINDOWS_TARGET_PLATFORM STREQUAL "arm64ec" AND
+     "${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+    target_link_options(${MODULE_TARGET} PRIVATE -lsoftintrin)
+  endif()
+
   set(MODULE_OUTPUT_DIR
     ${CMAKE_CURRENT_BINARY_DIR}/build/$<IF:$<CONFIG:Debug>,Debug,Release>)
   set_target_properties(${MODULE_TARGET} PROPERTIES


### PR DESCRIPTION
## Summary

This PR moves the Windows build to **Visual Studio 2026 (Clang 22 / MSVC 14.51)**,
switches **ARM64EC from MSVC to Clang**, and makes **ARM64 and ARM64EC first-class
in CI**: both now build the full target set and run the complete test suite on a
native ARM64 agent pool instead of being cross-compiled without tests.

ARM64 and ARM64EC had never been fully compiled (only `hermes.dll` /
`hermes-icu.dll` were) and no test had ever run against them. Everything else in
this PR is what it took to get there.

## Toolchain

- Visual Studio 2026 is now **required**. `build.js` locates it with
  `vswhere -version 18`; there is no VS 2022 fallback.
- `vs2022-msvc-*` CMake presets are replaced by `vs2026-msvc-{x64,x86,arm64}`
  (generator `Visual Studio 18 2026`). The Ninja presets are unchanged.
- ARM64EC no longer forces MSVC. It builds with Clang like every other target;
  `--msvc` still selects MSVC explicitly.
- Developer documentation is updated for the new required VS version and the
  correct component IDs.

## ARM64EC on Clang

The MSVC force was one line; making ARM64EC actually compile and link with Clang
was the bulk of the source change. Reviewers will find one root cause behind
almost all of it:

> ARM64EC deliberately advertises the **x64 predefined macros**
> (`__x86_64__`, `_M_X64`, `__SSE2__`) so that x64-targeting source keeps
> compiling. But Clang generates **AArch64** code there and ships **no x86
> intrinsics** — MSVC papered over this with softintrin-backed emulated
> intrinsics; Clang does not. Every guard keyed on an x64 macro must therefore
> also test `__arm64ec__`.

- Guard fixes (all mechanical, all in the shape above): `Support/SIMD.h` now
  selects NEON; `VM/Profiler.h` skips `<x86intrin.h>` / `__rdtsc`; llvh's
  `Host.cpp` skips the x86 `cpuid` / `xgetbv` inline asm; dragonbox drops the two
  `_umul128` / `_addcarry_u64` fast paths; folly reports `FOLLY_SSE 0` /
  `FOLLY_NEON 1` and emits an AArch64 `yield` for `asm_volatile_pause`.
- Boost's `fiber_winfib.hpp` gets the `BOOST_NO_EXCEPTIONS` guards
  `fiber_fcontext.hpp` already had. ARM64EC is the only target that uses winfib,
  and Clang hard-errors on `throw` / `try` under `-fno-exceptions` where MSVC did
  not.
- `softintrin.lib` is now linked for ARM64EC + Clang. MSVC emits a
  `/DEFAULTLIB:softintrin` directive automatically; Clang does not, so every link
  failed with `undefined symbol: _mm_getcsr (EC symbol)` from the UCRT
  floating-point objects. It is set in `CMAKE_EXE/SHARED_LINKER_FLAGS` so that
  CMake's configure-time `try_compile` checks link too, per-target for the
  `.node` test addons (MODULE libraries do not inherit those flags), and via
  `SHERMES_CC_SYSLDFLAGS` for the C that `shermes` generates and links.
- The `arm64ec-pc-windows-msvc` target triple is now passed regardless of host
  architecture, for both the main build and `shermes`: on an ARM64 host Clang's
  default target is plain **ARM64**, and non-EC objects cannot link against
  ARM64EC output. The MSVC-only `-arm64EC` flag injection is now MSVC-only.

### Static Hermes AOT: ARM64EC raw longjmp

`lib/VM/StaticH.cpp` is the one non-mechanical change. Static Hermes throws via
`setjmp`/`longjmp`, and the CRT's `longjmp` goes through `RtlUnwindEx`. The file
already used a raw longjmp on x64 and ARM64 to avoid unwinding across DLL
boundaries, but excluded ARM64EC — where the CRT path additionally trips
`RtlUnwindEx`'s Control Flow Guard check
(`FAST_FAIL_INVALID_LONGJUMP_TARGET`, `0xC0000409`) whenever the AOT module is
loaded into a CFG-enforced host process, which is exactly what `shermes -exec`
does.

The ARM64EC `_sh_raw_longjmp` restores the AArch64 callee-saved state from the
**x64-layout** `jmp_buf` (ARM64EC has no `_M_ARM64EC` branch in `setjmp.h`, and
`_M_ARM64EC` implies `_M_X64`), following the fixed ARM64EC x64↔AArch64 register
map. The mapping, the registers that are intentionally *not* restored (x23/x24/x28
are never used by ARM64EC codegen) and the `MxCsr` slot decision are documented in
the code. This turned 22 failing AOT lit tests into a clean run.

## CI and PR pipelines

- The top-level pool now demands `ImageOverride -equals windows-2025-1espt`,
  which is what moves x64, x86 and all UWP cells onto the VS 2026 image.
- `win32_arm64` and `win32_arm64ec` run on the `windows-2025-1espt-arm64` pool
  (single-image, so no `ImageOverride`) with `CanRunTest: true`. On a native host
  both stop being cross builds, so the tools, the unit-test binaries and the lit
  drivers are built, and the C++ unit tests, JS regression tests and Test262 Intl
  tests all run. The pool is selected by a per-cell `UseArm64Pool` flag rather
  than by `TargetCPU`, which keeps `uwp_arm64` on the x64 pool — UWP binaries are
  not executed by the pipeline on any architecture.
- ARM64EC is tested, not just built: the test executables are themselves ARM64EC
  and load the ARM64EC `hermes.dll` / `hermes-icu.dll`, so the shipped artifacts
  are what gets exercised.
- New `.ado/ensure-node10-shim.yml`, referenced first in the ARM64 jobs. ARM64
  agents ship no `externals\node10`, but the mandatory 1ES build-retention
  post-job still runs on the Node 10 task handler and would otherwise fail.
- New `.ado/image/README.md` documenting the pool ↔ image mapping. The image
  definitions themselves are shared with `microsoft/v8-jsi` and are not
  duplicated here.

### Agent environment

The new images differ from the old ones in ways the pipeline and the build
script had silently depended on:

- `UseNode@1` is removed. The images ship Node.js 24 on `PATH`; the task tried
  to provision a runtime instead, which the network-isolated PR pipeline blocks.
- The diagnostic file listing used `ls -R`, which is not on `cmd.exe`'s `PATH`
  on these images. It is now a `pwsh` step.
- Git Bash discovery in `build.js` is fixed. It used to take the first `git.exe`
  on `PATH` and rewrite `cmd` to `bin` in that path; on the new agents the first
  Git is the agent's own bundled copy, which has no `bash.exe`, so every lit
  test failed with *"Running Hermes LIT tests in CMD.exe is not supported"*. It
  now scans all `git.exe` locations plus the default install directories and
  picks one that actually contains `bash.exe`.

## Package contents

Because the ARM64 cells are now native builds, they also stage `hermes.exe` and
`hermesc.exe`. The NuGet package therefore carries tools for **every** target
platform (`tools\native\release\{x64,x86,arm64,arm64ec}\`) instead of only x64
and x86. The existing signing patterns and nuspec globs pick them up unchanged.

## Feed compliance

A repo-level `NuGet.config` pins package restore to the ADO feed, and the local
BinSkim download now uses that feed instead of nuget.org.

## Validation

All runs are Release, on VS 2026 18.8 / MSVC 14.51.36231 / Clang 22.1.3 /
Windows SDK 10.0.28000. ARM64 and ARM64EC were validated on a native ARM64 host.

| Target | Build | C++ unit tests | JS regression tests | Test262 Intl | BinSkim |
|---|---|---|---|---|---|
| x64 | 0 errors | 16/16 | 3064 pass, 0 unexpected | 100% (348/348) | — |
| x86 | 0 errors | 16/16 | 3063 pass, 0 unexpected | 100% (348/348) | — |
| arm64 | 0 errors | 16/16 | 3064 pass, 0 unexpected | 100% (348/348) | all rules pass |
| arm64ec | 0 errors | 16/16 | 3064 pass, 0 unexpected | 100% (348/348) | all rules pass |

JS regression runs additionally report the pre-existing 9 expected failures and
78 unsupported tests, unchanged from `main`.

Machine types verified with `dumpbin /headers` for `hermes.dll`, `hermes-icu.dll`
and the test executables: `AA64 machine (ARM64)` for arm64, and
`8664 machine (x64) (ARM64X)` for arm64ec.

## Notes for reviewers

- **Breaking for developers:** VS 2022 no longer builds this repo, and the
  `vs2022-msvc-*` presets are gone.
- ARM64 CI jobs are now real builds with three test suites, so those cells take
  substantially longer than the previous library-only cross builds.
- Vendored-dependency edits (llvh, folly, boost, dragonbox) are kept as small,
  additive `__arm64ec__` guards to minimize friction when syncing upstream.
