### PR TITLE
Cherry-pick facebook/hermes f617d6d5: don't cache dictionary-mode HiddenClass in the JSON.parse shape cache

### DIFF
--- a/lib/VM/JSLib/RuntimeJSONParse.cpp
+++ b/lib/VM/JSLib/RuntimeJSONParse.cpp
@@ -455,19 +455,24 @@ CallResult<HermesValue> RuntimeJSONParser<Kind>::parseValue() {
                         lv.curVal) == ExecutionStatus::EXCEPTION))
               return ExecutionStatus::EXCEPTION;
           }
-          // Populate cache entry
-          if (lv.hcCache->size() < depth + 1) {
-            if (LLVM_UNLIKELY(
-                    ArrayStorage::resize(lv.hcCache, runtime_, depth + 1) ==
-                    ExecutionStatus::EXCEPTION)) {
-              return ExecutionStatus::EXCEPTION;
+          // Populate cache entry. Dictionary-mode HiddenClasses are owned by
+          // a single object and mutated in place, so caching one would let a
+          // mutation on a sibling object grow the shared class past this
+          // object's propStorage (out-of-bounds access).
+          if (LLVM_LIKELY(!lv.newObject->getClass(runtime_)->isDictionary())) {
+            if (lv.hcCache->size() < depth + 1) {
+              if (LLVM_UNLIKELY(
+                      ArrayStorage::resize(lv.hcCache, runtime_, depth + 1) ==
+                      ExecutionStatus::EXCEPTION)) {
+                return ExecutionStatus::EXCEPTION;
+              }
             }
+            lv.hcCache->set(
+                depth,
+                HermesValue::encodeObjectValue(
+                    lv.newObject->getClass(runtime_), runtime_),
+                runtime_.getHeap());
           }
-          lv.hcCache->set(
-              depth,
-              HermesValue::encodeObjectValue(
-                  lv.newObject->getClass(runtime_), runtime_),
-              runtime_.getHeap());
         }
 
         ArrayStorageSmall::resizeWithinCapacity(

--- a/test/hermes/regress-shared-dictionary-hc-json.js
+++ b/test/hermes/regress-shared-dictionary-hc-json.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -O %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -exec %s | %FileCheck --match-full-lines %s
+
+// Regression: JSON.parse must not cache a dictionary-mode HiddenClass in
+// its per-depth shape cache. Dictionary classes are owned by exactly one
+// object and mutated in place; sharing one between two sibling parsed
+// objects with identical key sets lets a mutation on one corrupt the
+// other (out-of-bounds property storage access).
+
+// kDictionaryThreshold + 1: the slow-path object transitions to a dictionary.
+var N = 65;
+
+function mk(n) {
+  var s = '{';
+  for (var i = 0; i < n; i++) s += (i ? ',' : '') + '"k' + i + '":0';
+  return s + '}';
+}
+var arr = JSON.parse('[' + mk(N) + ',' + mk(N) + ']');
+
+// Deleting from arr[0] must not strip arr[1]'s property map.
+delete arr[0].k1;
+print(Object.keys(arr[1]).length);
+// CHECK: 65
+print(arr[1].k1);
+// CHECK-NEXT: 0
+
+// Adding to arr[0] must not extend arr[1]'s class (would be OOB on arr[1]).
+arr = JSON.parse('[' + mk(N) + ',' + mk(N) + ']');
+for (var i = 0; i < 8; i++) arr[0]['NEW' + i] = 'BAD';
+print(arr[1].NEW0, arr[1].NEW7);
+// CHECK-NEXT: undefined undefined
+print(Object.keys(arr[1]).length);
+// CHECK-NEXT: 65


### PR DESCRIPTION
This fork is missing an upstream fix. `lib/VM/JSLib/RuntimeJSONParse.cpp` here is byte-identical to `facebook/hermes` immediately **before** [`f617d6d5`](https://github.com/facebook/hermes/commit/f617d6d55a6d34e945510f5e726b5fc2e9f1c868) ("Fix dict HiddenClass sharing in JSON.parse cache", 2026-05-09), and `grep -c isDictionary` on the file returns 0 on `main` today. This PR cherry-picks that commit and its regression test verbatim — no changes of our own.

### Why it matters here

`parseValue`'s per-depth `HiddenClass` cache stores whatever the slow path produced, and `matchesHiddenClass()` does not test `isDictionary()`. Above `kDictionaryThreshold` (64 properties) the class is dictionary-mode, which is documented single-owner and mutated in place. Sibling objects parsed at the same depth then share one dictionary class: when one of them gains a new property the shared class grows, while the other siblings' `propStorage` does not, so subsequent access via that name runs past the end of their storage.

### Reproducer

Plain JS, no React Native, no embedder. `64` survives, `65` crashes — the threshold constant:

```js
var BASE = 65;                     // 64 survives, 65 crashes
function row(i) {
  var o = {};
  for (var f = 0; f < BASE; f++) o['F' + f] = 'v' + i + '_' + f;
  return o;
}
var raw = [];
for (var i = 0; i < 300; i++) raw.push(row(i));
var parsed = JSON.parse(JSON.stringify(raw));
for (var m = 0; m < parsed.length; m++) {
  if (!parsed[m].NEW_A) parsed[m].NEW_A = 'a' + m;
  if (!parsed[m].NEW_B) parsed[m].NEW_B = 'b' + m;
}
var bad = 0;
for (var k = 0; k < parsed.length; k++) {
  if (parsed[k].NEW_A !== 'a' + k || parsed[k].NEW_B !== 'b' + k) bad++;
}
print('base=' + BASE + ' mismatches=' + bad + ' SURVIVED');
```

Against the `hermes.exe` shipped in the `Microsoft.JavaScript.Hermes` packages, x64 Windows 11, two runs each:

| Package | Result |
| --- | --- |
| `0.0.0-2505.2001-0e4bc3b9` | prints `SURVIVED` (predates the shape cache) |
| `0.0.0-2604.21001-94aa5e1d` | exit 139 |
| `0.0.0-2607.16001-3c6569ec` | exit 139 |

Sweeping `BASE`: 40, 60, 62, 63, 64 all survive; 65, 70, 90 all crash.

### Where we hit it

A React Native Windows app on `0.0.0-2607.16001-3c6569ec`. Records arrive as sibling objects in a single `JSON.parse` of an API array, carry ~98 properties (over the threshold), and are then given a few additional keys. Reproducible on demand; the standalone script above reproduces it without the app, so nothing app-specific is needed to verify.

### Verification

We cannot build hermes-windows locally, so this has not been compiled here — the change is a verbatim cherry-pick of an upstream commit that carries its own regression test (`test/hermes/regress-shared-dictionary-hc-json.js`), and CI should exercise it. Happy to adjust if you would prefer a different sync strategy, e.g. a broader `static_h` sync rather than this single pick.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/363)