### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -9,6 +9,6 @@ runs:
   using: "composite"
   steps:
     - name: Setup node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ inputs.node-version }}

--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -9,6 +9,6 @@ runs:
   using: "composite"
   steps:
     - name: Setup xcode
-      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: ${{ inputs.xcode-version }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,12 @@ updates:
     all-npm-dependencies:
       patterns:
       - "*"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  groups:
+    github-actions:
+      patterns: ["*"]
+  schedule:
+    interval: "weekly"
+  cooldown:
+    default-days: 7

--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Download benchmark results artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: benchmark-results
           path: results
@@ -52,7 +52,7 @@ jobs:
 
       - name: Post or update PR comment
         if: steps.pr.outputs.skip != 'true' && steps.report.outputs.skip != 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
       actions: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - uses: ./.github/actions/setup-node
 
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: benchmark-results
           path: benchmark-results/

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -24,7 +24,7 @@ jobs:
         ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup git safe folders
         shell: bash
         run: git config --global --add safe.directory '*'
@@ -41,7 +41,7 @@ jobs:
           cd android
           ./gradlew publishAndroidOnlyToMavenTempLocal :build -PenableWarningsAsErrors=true
       - name: Upload Maven Artifacts
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
           name: maven-local
           path: /tmp/maven-local

--- a/.github/workflows/build-apple-slices-hermes.yml
+++ b/.github/workflows/build-apple-slices-hermes.yml
@@ -26,11 +26,11 @@ jobs:
           ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup xcode
         uses: ./.github/actions/setup-xcode
       - name: Restore HermesC Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: hermesc-apple
           path: ./build_host_hermesc
@@ -80,7 +80,7 @@ jobs:
         run: |
           tar -czv -f build_${{ matrix.slice }}_${{ matrix.flavor }}.tar.gz build_${{ matrix.slice }}_${{ matrix.flavor }}
       - name: Upload Artifact for Slice (${{ matrix.slice }}, ${{ matrix.flavor }})
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
           name: slice-${{ matrix.slice }}-${{ matrix.flavor }}
           path: ./build_${{ matrix.slice }}_${{ matrix.flavor }}.tar.gz

--- a/.github/workflows/build-hermes-macos.yml
+++ b/.github/workflows/build-hermes-macos.yml
@@ -14,7 +14,7 @@ jobs:
         flavor: [Debug, Release]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup xcode
         uses: ./.github/actions/setup-xcode
       - name: Setup node.js
@@ -22,7 +22,7 @@ jobs:
       - name: Yarn Install Dependencies
         uses: ./.github/actions/yarn-install
       - name: Download slice artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: slice-*-${{ matrix.flavor }}
           path: .
@@ -119,22 +119,22 @@ jobs:
           mkdir -p "$DEST_DIR"
           mv "hermesvm.framework.dSYM" "$DEST_DIR"
       - name: Upload hermes dSYM artifacts
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
           name: hermes-dSYM-${{ matrix.flavor }}
           path: /tmp/hermes/dSYM/${{ matrix.flavor }}
       - name: Upload hermes Runtime artifacts
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
           name: hermes-darwin-bin-${{ matrix.flavor }}
           path: /tmp/hermes/hermes-runtime-darwin/hermes-ios-${{ matrix.flavor }}.tar.gz
       - name: Upload hermes osx artifacts
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
           name: hermes-osx-bin-${{ matrix.flavor }}
           path: /tmp/hermes/osx-bin/${{ matrix.flavor }}
       - name: Upload Hermes Artifacts
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         if: ${{ github.ref == 'refs/heads/main' || contains(github.ref, '-stable') }} # To avoid that the cache explode.
         with:
           key: v4-hermes-artifacts-${{ matrix.flavor }}-${{ matrix.hermes-version }}-${{ matrix.react-native-version }}-${{ hashFiles('./packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}

--- a/.github/workflows/build-hermesc-apple.yml
+++ b/.github/workflows/build-hermesc-apple.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup xcode
         uses: ./.github/actions/setup-xcode
       - name: Build HermesC Apple
@@ -16,7 +16,7 @@ jobs:
           source ./utils/build-apple-framework.sh
           build_host_hermesc_if_needed
       - name: Upload HermesC Artifact
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
           name: hermesc-apple
           path: ./build_host_hermesc

--- a/.github/workflows/build-hermesc-linux.yml
+++ b/.github/workflows/build-hermesc-linux.yml
@@ -9,7 +9,7 @@ jobs:
       HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install dependencies
         shell: bash
         run: |
@@ -37,7 +37,7 @@ jobs:
           cmake --build build --target hermesc -j 4
           cp build/bin/hermesc /tmp/hermes/linux64-bin/.
       - name: Upload linux artifacts
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
           name: hermes-linux-bin
           path: /tmp/hermes/linux64-bin

--- a/.github/workflows/build-hermesc-windows.yml
+++ b/.github/workflows/build-hermesc-windows.yml
@@ -14,13 +14,13 @@ jobs:
       CMAKE_DIR: 'C:\Program Files\CMake\bin'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Set up workspace
         shell: powershell
         run: |
           mkdir -p C:\tmp\hermes\osx-bin
       - name: setup-msbuild
-        uses: microsoft/setup-msbuild@v1.3.2
+        uses: microsoft/setup-msbuild@031090342aeefe171e49f3820f3b52110c66e402 # v1.3.2
       - name: Set up workspace
         shell: powershell
         run: |
@@ -64,7 +64,7 @@ jobs:
           # Include Windows runtime dependencies
           Copy-Item -Path "$Env:HERMES_WS_DIR\deps\*" -Destination "$Env:HERMES_WS_DIR\win64-bin"
       - name: Upload windows artifacts
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
           name: hermes-win64-bin
           path: C:\tmp\hermes\win64-bin\

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,10 @@ jobs:
   macos:
     runs-on: macos-15
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
+    - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
       with:
         xcode-version: 16.2
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       with:
         path: hermes
     - name: Install dependencies
@@ -33,7 +33,7 @@ jobs:
         shasum -a 256 output/${TAR_NAME} > output/${TAR_NAME}.sha256
       env:
         TAR_NAME: hermes-cli-darwin.tar.gz
-    - uses: actions/upload-artifact@v4.3.1
+    - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
         name: macos-hermes
         path: output
@@ -53,10 +53,10 @@ jobs:
             test_runner_flags: "--vm-args='-Xjit=force'"
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
+    - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
       with:
         xcode-version: 16.2
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       with:
         path: hermes
     - name: Setup dependencies
@@ -90,7 +90,7 @@ jobs:
             test_runner_flags: "--vm-args='-Xjit=force'"
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       with:
         path: hermes
     - name: Setup dependencies
@@ -124,7 +124,7 @@ jobs:
     steps:
       # checkout action has problem running on container, currently using v1 can bypass it,
       # see https://github.com/actions/checkout/issues/334.
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
       - name: Setup dependencies
         run: |-
             apt update
@@ -173,7 +173,7 @@ jobs:
             cmake_flags: "-DBOOST_CONTEXT_IMPLEMENTATION=winfib"
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       with:
         path: hermes
     - name: Setup dependencies

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -39,7 +39,7 @@ jobs:
       issues: write
       actions: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           path: hermes
 
@@ -51,7 +51,7 @@ jobs:
           mkdir cmake-build
 
       - name: Build prompt
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const fs = require('fs');
@@ -138,7 +138,7 @@ jobs:
 
       - name: Post triage results
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
           CONCLUSION: ${{ steps.claude.outputs.conclusion }}
@@ -176,7 +176,7 @@ jobs:
 
       - name: Upload execution log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: claude-triage-${{ github.event.issue.number }}
           path: ${{ steps.claude.outputs.execution_file }}

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Print the target SHA and hermes version
         run: |
           echo "targetSha=${{ github.sha }}"
           echo "hermes-version=${{ inputs.hermes-version }}"
       - name: Create tag
         if: ${{ inputs.release-type == 'release' }}
-        uses: actions/github-script@v5
+        uses: actions/github-script@211cb3fefb35a799baa5156f9321bb774fe56294 # v5.2.0
         with:
           script: |
             github.rest.git.createRef({

--- a/.github/workflows/performance-test-rpi.yml
+++ b/.github/workflows/performance-test-rpi.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y cmake ninja-build clang-19 build-essential libicu-dev zip python3 git
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
       - name: Build Release
         run: |
           export CC=clang-19
@@ -22,7 +22,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release
           cmake --build build --target hermes hermesc
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: hermes-bin
           path: |
@@ -34,7 +34,7 @@ jobs:
             -out benchmark-bytecode/richards.hbc \
             benchmarks/bench-runner/resource/test-suites/v8-v6-perf/v8-richards.js
       - name: Upload benchmark bytecode
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: benchmark-bytecode
           path: benchmark-bytecode/
@@ -44,12 +44,12 @@ jobs:
     runs-on: raspberrypi5-8gb
     steps:
       - name: Download binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: hermes-bin
           path: hermes-bin
       - name: Download benchmark bytecode
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: benchmark-bytecode
           path: benchmark-bytecode

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       GHA_NPM_TOKEN: ${{ secrets.GHA_NPM_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup git safe folders
         shell: bash
         run: git config --global --add safe.directory '*'
@@ -33,42 +33,42 @@ jobs:
         shell: bash
         run: mkdir -p /tmp/hermes/osx-bin
       - name: Download osx-bin release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: hermes-osx-bin-Release
           path: /tmp/hermes/osx-bin/Release
       - name: Download osx-bin debug artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: hermes-osx-bin-Debug
           path: /tmp/hermes/osx-bin/Debug
       - name: Download darwin-bin release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: hermes-darwin-bin-Release
           path: /tmp/hermes/hermes-runtime-darwin
       - name: Download darwin-bin debug artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: hermes-darwin-bin-Debug
           path: /tmp/hermes/hermes-runtime-darwin
       - name: Download hermes dSYM debug artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: hermes-dSYM-Debug
           path: /tmp/hermes/dSYM/Debug
       - name: Download hermes dSYM release vartifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: hermes-dSYM-Release
           path: /tmp/hermes/dSYM/Release
       - name: Download linux-bin artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: hermes-linux-bin
           path: /tmp/hermes/linux64-bin
       - name: Download windows-bin artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: hermes-win64-bin
           path: /tmp/hermes/win64-bin
@@ -100,7 +100,7 @@ jobs:
         run: |
           node ./utils/scripts/hermes/publish-npm.js -t ${{ inputs.release-type }}
       - name: Upload npm logs
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
           name: npm-logs
           path: ~/.npm/_logs

--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -31,7 +31,7 @@ jobs:
       REF: ${{ github.ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup node.js
         uses: ./.github/actions/setup-node
       - name: Install node dependencies


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/369)