### PR TITLE
Fix dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,6 @@
 version: 2
-# Resolve npm/yarn updates through the ms/react-native-public feed (a public,
-# anonymous-read proxy of npmjs.org) so regenerated lockfiles stay feed-pinned.
-registries:
-  react-native-public:
-    type: npm-registry
-    url: https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/npm/registry/
-    # Public feed; no credentials needed.
-    replaces-base: true
 updates:
 - package-ecosystem: npm
-  registries:
-  - react-native-public
   directories:
   - "/"
   - "/.ado/scripts"

--- a/benchmarks/raytracer/original/.npmrc
+++ b/benchmarks/raytracer/original/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/npm/registry/


### PR DESCRIPTION
## Summary

Current dependabot settings cannot be parsed and as a result dependabot uses default settings.
This PR fix the issues to enable proper dependabot functionality.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/hermes-windows/pull/373)